### PR TITLE
Update CDN Typesafe maven releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val commonSettings = Seq(
   scalaVersion := scala212,
   resolvers ++= Seq(sonatypeReleases,
     "SonaType" at "https://oss.sonatype.org/content/groups/public",
-    "Typesafe maven releases" at "http://repo.typesafe.com/typesafe/maven-releases/",
+    "Typesafe maven releases" at "https://dl.bintray.com/typesafe/maven-releases/",
     sonatypeSnapshots,
     Resolver.mavenCentral),
   homepage := Some(url("https://github.com/ergoplatform/ergo-appkit")),


### PR DESCRIPTION
Typesafe did migrate to a new CDN lately.
Bintray has a [mirror of maven central](https://dl.bintray.com/typesafe/maven-releases/).