### PR TITLE
Sending ERG: Retry when NotEnoughCoinsForChangeBoxesError occurs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.iml
 *.toc
 *.aux
 *.log

--- a/common/src/main/java/org/ergoplatform/appkit/InputBoxesSelectionException.java
+++ b/common/src/main/java/org/ergoplatform/appkit/InputBoxesSelectionException.java
@@ -1,0 +1,19 @@
+package org.ergoplatform.appkit;
+
+public class InputBoxesSelectionException extends RuntimeException {
+
+    public InputBoxesSelectionException(String message) {
+        super(message);
+    }
+
+    /**
+     * Thrown when a change box is needed, but ERG amount in all inboxes is not enough to create the
+     * change box
+     */
+    public static class NotEnoughCoinsForChangeException extends InputBoxesSelectionException {
+
+        public NotEnoughCoinsForChangeException(String message) {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
Problem: When sending ERG, it could happen that an Inbox with an asset is selected. 

No problem in general, the asset is returned with a change box.

But when the amount of the selected Inbox can only satisfy the amount to send to the recipient, the NotEnoughCoinsForChangeBoxesError occurs. The user can't work around it, although the workaround is easy (when enough balance given): Just select another inbox. 

This approach makes a single retry to find more inboxes when the NotEnoughCoinsForChangeBoxesError occurs.

If you don't like this approach, I am open for other suggestions as well. Please also check the Scala file as I am not sure if the instance check is well done.