### PR TITLE
Use correct fee address on testnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ project/plugins/project/
 
 # IntelliJ Idea 
 .idea/
+*.iml
 
 # file system
 

--- a/common/src/main/java/org/ergoplatform/appkit/Parameters.java
+++ b/common/src/main/java/org/ergoplatform/appkit/Parameters.java
@@ -8,7 +8,8 @@ public class Parameters {
      * A number of blocks a miner should wait before he/she can spend block reward.
      * This is part of Ergo protocol and cannot be changed.
      */
-    public static final int MinerRewardDelay = 720;
+    public static final int MinerRewardDelay_Mainnet = 720;
+    public static final int MinerRewardDelay_Testnet = 72;
 
     /**
      * One Erg is 10^9 NanoErg

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/UnsignedTransactionBuilderImpl.scala
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/UnsignedTransactionBuilderImpl.scala
@@ -120,7 +120,10 @@ class UnsignedTransactionBuilderImpl(val _ctx: BlockchainContextImpl) extends Un
       inputs = inputBoxesSeq, dataInputs = dataInputs, outputCandidates = outputCandidatesSeq,
       currentHeight = _ctx.getHeight, createFeeOutput = _feeAmount,
       changeAddress = changeAddress, minChangeValue = MinChangeValue,
-      minerRewardDelay = Parameters.MinerRewardDelay, burnTokens = burnTokens,
+      minerRewardDelay =
+        if (_ctx.getNetworkType == NetworkType.MAINNET) Parameters.MinerRewardDelay_Mainnet
+        else Parameters.MinerRewardDelay_Testnet,
+      burnTokens = burnTokens,
       boxSelector = DefaultBoxSelector).get
     val stateContext = createErgoLikeStateContext
     new UnsignedTransactionImpl(tx, boxesToSpend, dataInputBoxes, stateContext)


### PR DESCRIPTION
On testnet, issueing transactions used the wrong fee address causing transactions only get mined if a miner sets minfee to 0. This PR fixes it.