### PR TITLE
Pass-through original DefaultBoxSelector error information

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,7 @@ assemblyMergeStrategy in assembly := {
 lazy val allConfigDependency = "compile->compile;test->test"
 
 val sigmaStateVersion = "4.0.4-23-08dc4c18-SNAPSHOT"
-val ergoWalletVersion = "4.0.12"
+val ergoWalletVersion = "4.0.16"
 lazy val sigmaState = ("org.scorexfoundation" %% "sigma-state" % sigmaStateVersion).force()
     .exclude("ch.qos.logback", "logback-classic")
     .exclude("org.scorexfoundation", "scrypto")

--- a/common/src/main/java/org/ergoplatform/appkit/InputBoxesSelectionException.java
+++ b/common/src/main/java/org/ergoplatform/appkit/InputBoxesSelectionException.java
@@ -1,0 +1,45 @@
+package org.ergoplatform.appkit;
+
+import java.util.Map;
+
+public class InputBoxesSelectionException extends RuntimeException {
+
+    public InputBoxesSelectionException(String message) {
+        super(message);
+    }
+
+    /**
+     * Thrown when a change box is needed, but ERG amount in all inboxes is not enough to create the
+     * change box
+     */
+    public static class NotEnoughCoinsForChangeException extends InputBoxesSelectionException {
+
+        public NotEnoughCoinsForChangeException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Thrown when the ERG amount needed was not found in all available boxes.
+     */
+    public static class NotEnoughErgsException extends InputBoxesSelectionException {
+        public final long balanceFound;
+
+        public NotEnoughErgsException(String message, long balanceFound) {
+            super(message);
+            this.balanceFound = balanceFound;
+        }
+    }
+
+    /**
+     * Thrown when a token amount needed was not found in all available boxes.
+     */
+    public static class NotEnoughTokensException extends InputBoxesSelectionException {
+        public final Map<String, Long> tokenBalances;
+
+        public NotEnoughTokensException(String message, Map<String, Long> tokenBalances) {
+            super(message);
+            this.tokenBalances = tokenBalances;
+        }
+    }
+}

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BoxSelectorsJavaHelpers.scala
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BoxSelectorsJavaHelpers.scala
@@ -42,7 +42,7 @@ object BoxSelectorsJavaHelpers {
           hm.put(elem._1.base16, elem._2)
           hm
         })
-        throw new NotEnoughTokensException("err.message", tokensHm)
+        throw new NotEnoughTokensException(err.message, tokensHm)
       }
       case Left(err) =>
         throw new InputBoxesSelectionException(

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BoxSelectorsJavaHelpers.scala
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BoxSelectorsJavaHelpers.scala
@@ -2,13 +2,20 @@ package org.ergoplatform.appkit
 
 import scala.collection.mutable
 import org.ergoplatform.wallet.boxes.DefaultBoxSelector
+import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughCoinsForChangeBoxesError
+import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughErgsError
+import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughTokensError
+
 import java.util.{List => JList, Map => JMap}
 import org.ergoplatform.appkit.JavaHelpers._
 import org.ergoplatform.appkit.Iso._
 import org.ergoplatform.ErgoBox.TokenId
 import org.ergoplatform.ErgoBoxAssets
 import org.ergoplatform.ErgoBoxAssetsHolder
-import scorex.util.{bytesToId, ModifierId}
+import org.ergoplatform.appkit.InputBoxesSelectionException.{NotEnoughErgsException, NotEnoughTokensException}
+import scorex.util.{ModifierId, bytesToId}
+
+import java.util
 
 
 object BoxSelectorsJavaHelpers {
@@ -20,14 +27,25 @@ object BoxSelectorsJavaHelpers {
   }
 
   def selectBoxes(unspentBoxes: JList[InputBox],
-                  amountToSpend: Long, 
+                  amountToSpend: Long,
                   tokensToSpend: JList[ErgoToken]): JList[InputBox] = {
     val inputBoxes = unspentBoxes.convertTo[IndexedSeq[InputBox]]
       .map(InputBoxWrapper.apply).toIterator
     val targetAssets = tokensToSpend.convertTo[mutable.LinkedHashMap[ModifierId, Long]].toMap
     val foundBoxes: IndexedSeq[InputBox] = DefaultBoxSelector.select(inputBoxes, amountToSpend, targetAssets) match {
-      case Left(err) => 
-        throw new RuntimeException(
+      case Left(err: NotEnoughCoinsForChangeBoxesError) =>
+          throw new InputBoxesSelectionException.NotEnoughCoinsForChangeException(err.message)
+      case Left(err: NotEnoughErgsError) =>
+          throw new NotEnoughErgsException(err.message, err.balanceFound)
+      case Left(err: NotEnoughTokensError) => {
+        val tokensHm = err.tokensFound.foldLeft(new util.HashMap[String, java.lang.Long])((hm, elem) => {
+          hm.put(elem._1.base16, elem._2)
+          hm
+        })
+        throw new NotEnoughTokensException("err.message", tokensHm)
+      }
+      case Left(err) =>
+        throw new InputBoxesSelectionException(
           s"Not enough funds in boxes to pay $amountToSpend nanoERGs, \ntokens: $tokensToSpend, \nreason: $err")
       case Right(v) => v.boxes.map(_.inputBox).toIndexedSeq
     }


### PR DESCRIPTION
For MrStahlfelge/ergo-wallet-android#25

This enables client to access the original error information returned from DefaultBoxSelector by repacking it into objects that Java can handle.

Not sure if my conversion into HashMap is the way to go, if there is a  better way please let me know.