### PR TITLE
Supporting Sigma v4.0.1 signing functions 

### DIFF
--- a/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
@@ -68,10 +68,14 @@ public interface ErgoProver {
 
     byte[] signMessage(SigmaBoolean sigmaTree, byte[] message, HintsBag hintsBag);
 
+    byte[] signMessage(P2PKAddress addr, byte[] message, HintsBag hintsBag);
+
     ReducedTransaction reduce(UnsignedTransaction tx, int baseCost);
 
     SignedTransaction signReduced(ReducedTransaction tx, int baseCost);
 
-    boolean verifySignature(SigmaBoolean tx, byte[] message, byte[] signedMessage);
+    boolean verifySignature(SigmaBoolean sigmaTree, byte[] message, byte[] signedMessage);
+    
+    boolean verifySignature(P2PKAddress addr, byte[] message, byte[] signedMessage);
 }
 

--- a/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
@@ -91,7 +91,7 @@ public interface ErgoProver {
 
     SignedTransaction signReduced(ReducedTransaction tx, int baseCost);
 
-     /**
+    /**
      * Verifies a signature on given (arbitrary) message for a given public key.
      *
      * @param sigmaTree public key (represented as a tree)

--- a/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
@@ -101,7 +101,7 @@ public interface ErgoProver {
      */
     boolean verifySignature(SigmaBoolean sigmaTree, byte[] message, byte[] signedMessage);
 
-     /**
+    /**
      * Verifies a signature on given (arbitrary) message for a 
      * using an address' public key.
      *

--- a/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
@@ -66,16 +66,50 @@ public interface ErgoProver {
      */
     SignedTransaction sign(UnsignedTransaction tx, int baseCost);
 
+    /**
+     * Signs an arbitrary message under a key representing a 
+     * statement provable via a sigma-protocol.
+     *
+     * @param sigmaTree public key
+     * @param message message to sign
+     * @param hintsBag additional hints for a signer (useful for distributed signing)
+     * @return signed message
+     */
     byte[] signMessage(SigmaBoolean sigmaTree, byte[] message, HintsBag hintsBag);
 
+    /**
+     * Signs an arbitrary message using a p2k address
+     *
+     * @param addr address whose public key will be used to sign message
+     * @param message message to sign
+     * @param hintsBag additional hints for a signer (useful for distributed signing)
+     * @return signed message
+     */
     byte[] signMessage(P2PKAddress addr, byte[] message, HintsBag hintsBag);
 
     ReducedTransaction reduce(UnsignedTransaction tx, int baseCost);
 
     SignedTransaction signReduced(ReducedTransaction tx, int baseCost);
 
+     /**
+     * Verifies a signature on given (arbitrary) message for a given public key.
+     *
+     * @param sigmaTree public key (represented as a tree)
+     * @param message message to verify
+     * @param signedMessage signature for the message
+     * @return whether signature is valid or not
+     */
     boolean verifySignature(SigmaBoolean sigmaTree, byte[] message, byte[] signedMessage);
-    
+
+     /**
+     * Verifies a signature on given (arbitrary) message for a 
+     * using an address' public key.
+     *
+     * @param addr address whose public key will be used to verify message
+     * @param message message to verify
+     * @param signedMessage signature for the message
+     * @return whether signature is valid or not
+     */
     boolean verifySignature(P2PKAddress addr, byte[] message, byte[] signedMessage);
 }
 

--- a/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
@@ -4,6 +4,9 @@ import org.ergoplatform.P2PKAddress;
 import org.ergoplatform.wallet.protocol.context.ErgoLikeParameters;
 import special.sigma.BigInt;
 
+import sigmastate.Values.SigmaBoolean;
+import sigmastate.interpreter.HintsBag;
+
 import java.util.List;
 
 /**
@@ -63,8 +66,12 @@ public interface ErgoProver {
      */
     SignedTransaction sign(UnsignedTransaction tx, int baseCost);
 
+    byte[] signMessage(SigmaBoolean sigmaTree, byte[] message, HintsBag hintsBag);
+
     ReducedTransaction reduce(UnsignedTransaction tx, int baseCost);
 
     SignedTransaction signReduced(ReducedTransaction tx, int baseCost);
+
+    boolean verifySignature(SigmaBoolean tx, byte[] message, byte[] signedMessage);
 }
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoProverImpl.scala
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoProverImpl.scala
@@ -6,6 +6,8 @@ import org.ergoplatform.P2PKAddress
 import org.ergoplatform.appkit._
 import org.ergoplatform.wallet.secrets.ExtendedSecretKey
 import sigmastate.eval.CostingSigmaDslBuilder
+import sigmastate.Values.{SigmaBoolean}
+import sigmastate.interpreter.HintsBag
 import special.sigma.BigInt
 import sigmastate.utils.Helpers._  // don't remove, required for Scala 2.11
 import JavaHelpers._
@@ -46,6 +48,11 @@ class ErgoProverImpl(_ctx: BlockchainContextBase,
     new SignedTransactionImpl(_ctx, signed, cost)
   }
 
+  def signMessage(sigmaTree: SigmaBoolean, message:  Array[Byte], hintsBag: HintsBag): Array[Byte] = {
+    _prover.signMessage(sigmaTree, message, hintsBag).getOrThrow
+  }
+
+
   override def reduce(tx: UnsignedTransaction, baseCost: Int): ReducedTransaction = {
     val txImpl = tx.asInstanceOf[UnsignedTransactionImpl]
     val boxesToSpend = JavaHelpers.toIndexedSeq(txImpl.getBoxesToSpend)
@@ -58,5 +65,10 @@ class ErgoProverImpl(_ctx: BlockchainContextBase,
     val (signed, cost) = _prover.signReduced(tx.getTx, baseCost)
     new SignedTransactionImpl(_ctx, signed, cost)
   }
+
+  override def verifySignature(sigmaTree: SigmaBoolean, message: Array[Byte], signedMessage: Array[Byte]): Boolean = {
+    _prover.verifySignature(sigmaTree, message, signedMessage)
+  }
+
 }
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoProverImpl.scala
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoProverImpl.scala
@@ -52,6 +52,9 @@ class ErgoProverImpl(_ctx: BlockchainContextBase,
     _prover.signMessage(sigmaTree, message, hintsBag).getOrThrow
   }
 
+  def signMessage(addr: P2PKAddress, message:  Array[Byte], hintsBag: HintsBag): Array[Byte] = {
+    _prover.signMessage(addr.pubkey, message, hintsBag).getOrThrow
+  }
 
   override def reduce(tx: UnsignedTransaction, baseCost: Int): ReducedTransaction = {
     val txImpl = tx.asInstanceOf[UnsignedTransactionImpl]
@@ -68,6 +71,10 @@ class ErgoProverImpl(_ctx: BlockchainContextBase,
 
   override def verifySignature(sigmaTree: SigmaBoolean, message: Array[Byte], signedMessage: Array[Byte]): Boolean = {
     _prover.verifySignature(sigmaTree, message, signedMessage)
+  }
+
+  override def verifySignature(addr: P2PKAddress, message: Array[Byte], signedMessage: Array[Byte]): Boolean = {
+    _prover.verifySignature(addr.pubkey, message, signedMessage)
   }
 
 }

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoProverImpl.scala
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoProverImpl.scala
@@ -48,11 +48,11 @@ class ErgoProverImpl(_ctx: BlockchainContextBase,
     new SignedTransactionImpl(_ctx, signed, cost)
   }
 
-  def signMessage(sigmaTree: SigmaBoolean, message:  Array[Byte], hintsBag: HintsBag): Array[Byte] = {
+  override def signMessage(sigmaTree: SigmaBoolean, message:  Array[Byte], hintsBag: HintsBag): Array[Byte] = {
     _prover.signMessage(sigmaTree, message, hintsBag).getOrThrow
   }
 
-  def signMessage(addr: P2PKAddress, message:  Array[Byte], hintsBag: HintsBag): Array[Byte] = {
+  override def signMessage(addr: P2PKAddress, message:  Array[Byte], hintsBag: HintsBag): Array[Byte] = {
     _prover.signMessage(addr.pubkey, message, hintsBag).getOrThrow
   }
 


### PR DESCRIPTION
https://github.com/ergoplatform/ergo-appkit/issues/65

👋  ErgoTeam,  I took on this issue to get more familiar with the code base.  (tagged as `Good first issue`)
If the code in this PR makes sense I am happy to continue adding the needed unit-tests.

The API side of these changes are made in other PR on the ergo repo: https://github.com/ergoplatform/ergo/pull/1484/files

@aslesarenko I was also wondering if passing a SigmaBoolean makes sense at all. I was thinking on just passing the public key i.e:

```scala
 // no tx here
  def signMessage(message:  Array[Byte], hintsBag: HintsBag): Array[Byte] = {
     pk = _prover.publicKeys.head 
    _prover.signMessage(pk, message, hintsBag).getOrThrow
  }
```

----
- [x] unit tests