### PR TITLE
BlockchainContextImpl.getUnspentBoxesFor: skip boxes unknown to node

### DIFF
--- a/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainContext.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainContext.java
@@ -87,7 +87,8 @@ public interface BlockchainContext {
      * @param address owner of the boxes to be retrieved
      * @param offset  optional zero based offset of the first box in the list,
      *                default = 0
-     * @param limit   optional number of boxes to retrive (default = 20)
+     * @param limit   optional number of boxes to retrieve. Note that returned list might
+     *                contain less elements if data for some boxes couldn't be retrieved
      * @return a requested chunk of boxes owned by the address
      */
     List<InputBox> getUnspentBoxesFor(Address address, int offset, int limit);

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainContext.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainContext.java
@@ -40,7 +40,7 @@ public interface BlockchainContext {
      * @param boxIds array of string encoded ids of the boxes in the UTXO.
      * @return an array of requested boxes suitable for spending in transactions
      * created using this context.
-     * @throws ErgoClientException if some boxes are not avaliable.
+     * @throws ErgoClientException if some boxes are not available.
      */
     InputBox[] getBoxesById(String... boxIds) throws ErgoClientException;
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/BlockchainContextImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/BlockchainContextImpl.java
@@ -98,7 +98,11 @@ public class BlockchainContextImpl extends BlockchainContextBase {
         for (OutputInfo box : boxes) {
             String boxId = box.getBoxId();
             ErgoTransactionOutput boxInfo = ErgoNodeFacade.getBoxById(_retrofit, boxId);
-            returnList.add(new InputBoxImpl(this, boxInfo));
+            // can be null if node does not know about the box (yet)
+            // instead of throwing an error, we continue with the boxes actually known
+            if (boxInfo != null) {
+                returnList.add(new InputBoxImpl(this, boxInfo));
+            }
         }
 
         return returnList;
@@ -177,7 +181,7 @@ public class BlockchainContextImpl extends BlockchainContextBase {
                 }
             }
             // this chunk is not enough, go to the next (if any)
-            if (chunk.size() < DEFAULT_LIMIT_FOR_API) {
+            if (chunk.size() == 0) {
                 // this was the last chunk, but still remain to collect
                 assert remainingAmountToCover > 0 || !tokensRemaining.areTokensCovered();
                 // cannot satisfy the request, but still return cb, with cb.isCovered == false

--- a/lib-impl/src/test/java/org/ergoplatform/appkit/impl/BlockchainContextImplTest.java
+++ b/lib-impl/src/test/java/org/ergoplatform/appkit/impl/BlockchainContextImplTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class BlockchainContextImplTest extends ApiTestBase {
@@ -71,7 +72,10 @@ public class BlockchainContextImplTest extends ApiTestBase {
 
         @Override
         public List<InputBox> getUnspentBoxesFor(Address address, int offset, int limit) {
-            return unspentBoxesMock;
+            if (offset >= limit)
+                return Collections.emptyList();
+            else
+                return unspentBoxesMock;
         }
     }
 }


### PR DESCRIPTION
`BlockchainContextImpl.getUnspentBoxesFor` returns a list of unspent boxes. However, when the node it connects to is not in full sync, certain box information can't be retrieved. This causes an NPE and no unspend box can be retrieved.

With this change, instead of throwing an NPE a null object is added to the list. This way, the applications can see that some information is missing (and not confuse a smaller chunk size with the end of the list), but can continue working with other available unspent boxes.