### PR TITLE
Fix problem when using BoxOperations.loadTop for single sender address to select token boxes

### DIFF
--- a/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
@@ -87,7 +87,7 @@ public class BoxOperations {
         Address sender, long amount,
         List<ErgoToken> tokensToSpend) {
         CoveringBoxes unspent = ctx.getCoveringBoxesFor(sender, amount, tokensToSpend);
-        List<InputBox> selected = selectTop(unspent.getBoxes(), amount);
+        List<InputBox> selected = selectTop(unspent.getBoxes(), amount, tokensToSpend);
         return selected;
     }
 


### PR DESCRIPTION
Cause: BoxOperations.loadTop for single sender address did not select boxes for tokens properly