### PR TITLE
Explorer API: Add sortDirection to getApiV1BoxesUnspentByaddressP1

### DIFF
--- a/java-client-generated/src/main/java/org/ergoplatform/explorer/client/DefaultApi.java
+++ b/java-client-generated/src/main/java/org/ergoplatform/explorer/client/DefaultApi.java
@@ -198,7 +198,7 @@ public interface DefaultApi {
    */
   @GET("api/v1/boxes/unspent/byAddress/{p1}")
   Call<ItemsA> getApiV1BoxesUnspentByaddressP1(
-            @retrofit2.http.Path("p1") String p1            ,     @retrofit2.http.Query("offset") Integer offset                ,     @retrofit2.http.Query("limit") Integer limit                
+            @retrofit2.http.Path("p1") String p1            ,     @retrofit2.http.Query("offset") Integer offset                ,     @retrofit2.http.Query("limit") Integer limit,     @retrofit2.http.Query("sortDirection") String sortDirection
   );
 
   /**

--- a/java-client-generated/src/test/java/org/ergoplatform/explorer/client/DefaultApiTest.java
+++ b/java-client-generated/src/test/java/org/ergoplatform/explorer/client/DefaultApiTest.java
@@ -139,7 +139,7 @@ public class DefaultApiTest extends ApiTestBase {
     public void getApiV1BoxesUnspentByaddressP1Test() throws IOException {
         Integer offset = 0;
         Integer limit = 10;
-        ItemsA response = api.getApiV1BoxesUnspentByaddressP1(address, offset, limit).execute().body();
+        ItemsA response = api.getApiV1BoxesUnspentByaddressP1(address, offset, limit, "asc").execute().body();
         assertTrue(response.getItems().size() > 0);
     }
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ExplorerFacade.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ExplorerFacade.java
@@ -28,9 +28,9 @@ public class ExplorerFacade extends ApiFacade {
             Retrofit r, String id, Integer offset, Integer limit) throws ErgoClientException {
         return execute(r, () -> {
             Method method = DefaultApi.class.getMethod(
-              "getApiV1BoxesUnspentByaddressP1", String.class, Integer.class, Integer.class);
+              "getApiV1BoxesUnspentByaddressP1", String.class, Integer.class, Integer.class, String.class);
             ItemsA res =
-                    RetrofitUtil.<ItemsA>invokeServiceMethod(r, method, new Object[]{id, offset, limit})
+                    RetrofitUtil.<ItemsA>invokeServiceMethod(r, method, new Object[]{id, offset, limit, "asc"})
                             .execute().body();
             return res.getItems();
         });


### PR DESCRIPTION
ergoplatform/explorer-backend#153 reversed ordering of getApiV1BoxesUnspentByaddressP1, making users spent their newest UTXO instead of their oldest one as before.
New param to configure behaviour was added with ergoplatform/explorer-backend#155

This param is now added here and used to resemble the old behaviour.