### PR TITLE
BoxOperations refactoring, add way to ignore boxes spent in mempool for box collection

### DIFF
--- a/appkit/src/test/resources/mockwebserver/node_responses/response_mempool.json
+++ b/appkit/src/test/resources/mockwebserver/node_responses/response_mempool.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "72b1ffcc5cb2684b832291927f0b52b845f9f740b81e3766cba22c51fc3aa42e",
+    "inputs": [
+      {
+        "boxId": "d47f958b201dc7162f641f7eb055e9fa7a9cb65cc24d4447a10f86675fc58328",
+        "spendingProof": {
+          "proofBytes": "9f195a873f885fa88adfd0dbc00a4db047057ceab3afa07fc5dae3c9a185498643f1b2086a7d60b3dc8787ad79a55cc678cb5ca445cbeafc",
+          "extension": { }
+        }
+      }
+    ],
+    "dataInputs": [ ],
+    "outputs": [
+      {
+        "boxId": "838a1034a5855a23bb23da21a8370430a915fa4f9a806acf082167416189d52a",
+        "value": 3000000,
+        "ergoTree": "1005040004640e240008cd021cf57743cfe2a885dbbd5b7dea38a51f72754f13249fd6b6b2bdbb14cdf1840e0e9802100e0400040004000500040405020580897a0e240008cd021cf57743cfe2a885dbbd5b7dea38a51f72754f13249fd6b6b2bdbb14cdf1840e0e0201010e20781c3e1861786a8f53991e7caad65c40a3fe319218a32752df74887e8500d72605000580a4e8030e240008cd021cf57743cfe2a885dbbd5b7dea38a51f72754f13249fd6b6b2bdbb14cdf1840e05e6aeb193dd5fd804d601b2a5730000d602c17201d603c5b2a4730100d604b2db63087201730201860272037303d1eded93b1a57304ecededededed9372038c720401938c7204027305937202730693c27201730793e4c67201070e730893e4c67201080e7309ed92720299b0a4730ad9010541639a8c720501c18c720502730b93c27201730c8f7ea305730d0404d1d801d601b2a5730000ededed93e4c672010404730193e4c67201050e730293c27201730393b1a57304",
+        "assets": [ ],
+        "creationHeight": 683785,
+        "additionalRegisters": { },
+        "transactionId": "72b1ffcc5cb2684b832291927f0b52b845f9f740b81e3766cba22c51fc3aa42e",
+        "index": 0
+      },
+      {
+        "boxId": "1ee8a5f6eea1ea25fd18c87bd918cdf0b55c6392cd906d85c6dd7b11ba0e939b",
+        "value": 1000000,
+        "ergoTree": "1005040004000e36100204a00b08cd0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ea02d192a39a8cc7a701730073011001020402d19683030193a38cc7b2a57300000193c2b2a57301007473027303830108cdeeac93b1a57304",
+        "assets": [ ],
+        "creationHeight": 683785,
+        "additionalRegisters": { },
+        "transactionId": "72b1ffcc5cb2684b832291927f0b52b845f9f740b81e3766cba22c51fc3aa42e",
+        "index": 1
+      },
+      {
+        "boxId": "fab1e4767952460cb0e922e9f6686af62de79507530ebac0ae91ecc0e0845822",
+        "value": 909400000,
+        "ergoTree": "0008cd021cf57743cfe2a885dbbd5b7dea38a51f72754f13249fd6b6b2bdbb14cdf1840e",
+        "assets": [
+          {
+            "tokenId": "f446d4514eb48d62b84dc78c3458986abfb9cc56c04af1db5da5034ee9de5805",
+            "amount": 1
+          }
+        ],
+        "creationHeight": 683785,
+        "additionalRegisters": { },
+        "transactionId": "72b1ffcc5cb2684b832291927f0b52b845f9f740b81e3766cba22c51fc3aa42e",
+        "index": 2
+      }
+    ],
+    "size": 757
+  },
+  {
+
+    "id": "a06ea82554498c8e16fe05457d7277a23ab0c5e23ee4c4d12e1028ed98a98183",
+    "inputs": [
+      {
+        "boxId": "26d6e08027e005270b38e5c5f4a73ffdb6d65a3289efb51ac37f98ad395d887c",
+        "spendingProof": {
+          "proofBytes": "0d3326b4e941f710ae750bc72883bf72b42712ddfbff8fc3685288579cfd2884d2b306ed5615822c9deba74f18851821ab8cd6f20d1fd397",
+          "extension": { }
+        }
+      },
+      {
+        "boxId": "156aa980fbe19ec6bf422b074e80e14bdf14a9216b2ed90c1ff95cddd1ecb21a",
+        "spendingProof": {
+          "proofBytes": "dc5d9e56624fb23e5b2eefacb48a4f587c583395f0ae49ae72faa60054e82f7eb74139d28f349057c24f7bc8e643c8486636d75d20fb79b3",
+          "extension": { }
+        }
+      }
+    ],
+    "dataInputs": [ ],
+    "outputs": [
+      {
+        "boxId": "1374b11eb329d9493bce79e3e0aecce1ee3b792fa2ba50a4aef0d7685bd3afe0",
+        "value": 3000000,
+        "ergoTree": "1005040004640e240008cd025e8a8a999ab75fa878a6222f44ce975aa9c57081e82709fc6e73120f8460b9cd0e9802100e0400040004000500040405020580897a0e240008cd025e8a8a999ab75fa878a6222f44ce975aa9c57081e82709fc6e73120f8460b9cd0e0201010e20305f51926124907ce01f9015e2af7ef22ab0d4568647991c6d1d7e89839fab8405000580a4e8030e240008cd025e8a8a999ab75fa878a6222f44ce975aa9c57081e82709fc6e73120f8460b9cd05c485a193dd5fd804d601b2a5730000d602c17201d603c5b2a4730100d604b2db63087201730201860272037303d1eded93b1a57304ecededededed9372038c720401938c7204027305937202730693c27201730793e4c67201070e730893e4c67201080e7309ed92720299b0a4730ad9010541639a8c720501c18c720502730b93c27201730c8f7ea305730d0404d1d801d601b2a5730000ededed93e4c672010404730193e4c67201050e730293c27201730393b1a57304",
+        "assets": [ ],
+        "creationHeight": 683784,
+        "additionalRegisters": { },
+        "transactionId": "a06ea82554498c8e16fe05457d7277a23ab0c5e23ee4c4d12e1028ed98a98183",
+        "index": 0
+      },
+      {
+        "boxId": "2197c2e43089d3ffe64bd3e6bfc32152857285a243cfc48ead217bd76b3802dc",
+        "value": 1000000,
+        "ergoTree": "1005040004000e36100204a00b08cd0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ea02d192a39a8cc7a701730073011001020402d19683030193a38cc7b2a57300000193c2b2a57301007473027303830108cdeeac93b1a57304",
+        "assets": [ ],
+        "creationHeight": 683784,
+        "additionalRegisters": { },
+        "transactionId": "a06ea82554498c8e16fe05457d7277a23ab0c5e23ee4c4d12e1028ed98a98183",
+        "index": 1
+      },
+      {
+        "boxId": "3b1bb001e5fc3112f2106bedb51a4873d2ed1f3804b3735adac7f6f0b70130cf",
+        "value": 1224400000,
+        "ergoTree": "0008cd025e8a8a999ab75fa878a6222f44ce975aa9c57081e82709fc6e73120f8460b9cd",
+        "assets": [
+          {
+            "tokenId": "fb59f2ab3dc432788f529553a47bf963f586845a0080c4f8563c7c1ed0fe5a59",
+            "amount": 1
+          }
+        ],
+        "creationHeight": 683784,
+        "additionalRegisters": { },
+        "transactionId": "a06ea82554498c8e16fe05457d7277a23ab0c5e23ee4c4d12e1028ed98a98183",
+        "index": 2
+      }
+    ],
+    "size": 757
+
+  }
+]

--- a/appkit/src/test/scala/org/ergoplatform/appkit/AnonymousAccessSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/AnonymousAccessSpec.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.appkit
 
 import java.util
 
-import org.ergoplatform.appkit.BoxOperations.{createProver, loadTop, putToContractTx}
+import org.ergoplatform.appkit.BoxOperations.{createProver}
 import org.ergoplatform.appkit.Parameters.MinFee
 import org.ergoplatform.appkit.impl.ErgoTreeContract
 import org.ergoplatform.appkit.testing.AppkitTesting
@@ -119,7 +119,7 @@ object DhtUtils {
        |  proveDHTuple(groupGenerator, g_y, g_x, g_xy)    // for alice
        |}""".stripMargin);
 
-    val dhtBoxCreationTx = putToContractTx(ctx, sender, false, contract, amountToSend, new util.ArrayList[ErgoToken]())
+    val dhtBoxCreationTx = new BoxOperations(sender, false).withAmountToSpend(amountToSend).putToContractTx(ctx, contract)
     dhtBoxCreationTx
   }
 
@@ -131,7 +131,7 @@ object DhtUtils {
         .registers(ErgoValue.of(g_y), ErgoValue.of(g_xy))
         .build
 
-    val boxesToPayFee = loadTop(ctx, sender.getAddress, MinFee, new util.ArrayList[ErgoToken]())
+    val boxesToPayFee = new BoxOperations(sender.getAddress).loadTop(ctx)
 
     val inputs = new util.ArrayList[InputBox]()
     inputs.add(dhtBox)

--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -1,21 +1,21 @@
 package org.ergoplatform.appkit
 
-import java.io.File
-import java.math.BigInteger
-import java.util
-import java.util.Arrays
-
-import org.ergoplatform.{ErgoBox, ErgoScriptPredef}
-import org.ergoplatform.appkit.impl.{ErgoTreeContract, ReducedTransactionImpl, BlockchainContextBase}
+import org.ergoplatform.appkit.InputBoxesSelectionException.NotEnoughErgsException
+import org.ergoplatform.appkit.impl.{BlockchainContextImpl, ErgoTreeContract, ExplorerAndPoolUnspentBoxesLoader}
 import org.ergoplatform.appkit.testing.AppkitTesting
 import org.ergoplatform.restapi.client
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{PropSpec, Matchers}
+import org.ergoplatform.{ErgoBox, ErgoScriptPredef}
 import org.scalacheck.Gen
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scorex.util.ModifierId
-import sigmastate.eval.{CBigInt, CostingBox}
+import sigmastate.eval.CBigInt
 import sigmastate.helpers.NegativeTesting
 import sigmastate.interpreter.HintsBag
+
+import java.io.File
+import java.math.BigInteger
+import java.util.Arrays
 
 class TxBuilderSpec extends PropSpec with Matchers
   with ScalaCheckDrivenPropertyChecks
@@ -312,6 +312,41 @@ class TxBuilderSpec extends PropSpec with Matchers
       val deserializedSignedTx = ctx.parseSignedTransaction(signed.toBytes)
       deserializedSignedTx shouldBe signed
     }
+  }
+
+  property("omit mempool boxes") {
+    val ergoClient = createMockedErgoClient(MockData(
+      Seq(
+        loadNodeResponse("response_mempool.json"),
+        loadNodeResponse("response_Box1.json"),
+        loadNodeResponse("response_Box2.json"),
+        loadNodeResponse("response_Box3.json")),
+      Seq(
+        loadExplorerResponse("response_boxesByAddressUnspent.json"),
+        "{ \"items\": [ ], \"total\": 0\n}")))
+
+    a[NotEnoughErgsException] shouldBe thrownBy {
+      ergoClient.execute { ctx: BlockchainContext =>
+        val storage = SecretStorage.loadFrom("storage/E2.json")
+        storage.unlock("abc")
+
+        val recipient = address
+
+        val amountToSend = 1000000
+        val pkContract = new ErgoTreeContract(recipient.getErgoAddress.script)
+
+        val senders = Arrays.asList(storage.getAddressFor(NetworkType.MAINNET))
+        val unsigned = new BoxOperations(senders).withAmountToSpend(amountToSend)
+          .withInputBoxesLoader(new ExplorerAndPoolUnspentBoxesLoader(ctx.asInstanceOf[BlockchainContextImpl]))
+          .putToContractTxUnsigned(ctx, pkContract)
+
+        val prover = ctx.newProverBuilder.build // prover without secrets
+        val reduced = prover.reduce(unsigned, 0)
+        reduced should not be (null)
+        reduced
+      }
+    }
+
   }
 
   property("Special tx building cases") {

--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -254,9 +254,8 @@ class TxBuilderSpec extends PropSpec with Matchers
 
       val recipient = senderProver.getEip3Addresses.get(1)
       val amountToSend = 1000000
-      val pkContract = new ErgoTreeContract(recipient.getErgoAddress.script)
-      val signed = BoxOperations.putToContractTx(ctx,
-          senderProver, false, pkContract, amountToSend, new util.ArrayList[ErgoToken]())
+      val signed = new BoxOperations(senderProver, false).withAmountToSpend(amountToSend)
+        .send(ctx, recipient)
       assert(signed != null)
     }
   }
@@ -274,9 +273,7 @@ class TxBuilderSpec extends PropSpec with Matchers
       val pkContract = new ErgoTreeContract(recipient.getErgoAddress.script)
 
       val senders = Arrays.asList(storage.getAddressFor(NetworkType.MAINNET))
-      val unsigned = BoxOperations.putToContractTxUnsigned(ctx,
-        senders, pkContract, amountToSend,
-        new util.ArrayList[ErgoToken]())
+      val unsigned = new BoxOperations(senders).withAmountToSpend(amountToSend).putToContractTxUnsigned(ctx, pkContract)
 
       val prover = ctx.newProverBuilder.build // prover without secrets
       val reduced = prover.reduce(unsigned, 0)

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainContext.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainContext.java
@@ -3,6 +3,7 @@ package org.ergoplatform.appkit;
 import sigmastate.Values;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * This interface represent a specific context of blockchain for execution
@@ -96,6 +97,8 @@ public interface BlockchainContext {
     /**
      * Get unspent boxes owned by the given address starting from the given offset up to
      * the given limit (basically one page of the boxes).
+     * Uses {@link BoxOperations#getCoveringBoxesFor(long, List, Function)} with
+     * Explorer API as data source.
      *
      * @param address owner of the boxes to be retrieved
      * @param amountToSpend amount of NanoErgs to be covered

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainContext.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainContext.java
@@ -100,11 +100,14 @@ public interface BlockchainContext {
      * Uses {@link BoxOperations#getCoveringBoxesFor(long, List, Function)} with
      * Explorer API as data source.
      *
+     * Deprecated - call {@link BoxOperations#getCoveringBoxesFor(long, List, Function)} directly
+     *
      * @param address owner of the boxes to be retrieved
      * @param amountToSpend amount of NanoErgs to be covered
      * @param tokensToSpend ErgoToken to spent
      * @return a new instance of {@link CoveringBoxes} set
      */
+    @Deprecated
     CoveringBoxes getCoveringBoxesFor(Address address, long amountToSpend, List<ErgoToken> tokensToSpend);
 
     /**

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
@@ -307,13 +307,14 @@ public class BoxOperations {
      * - must not return null
      * - returning an empty list means the source of input boxes is drained and no further page will be loaded
      */
-    interface IUnspentBoxesLoader {
+    public interface IUnspentBoxesLoader {
         @Nonnull
         List<InputBox> loadBoxesPage(@Nonnull BlockchainContext ctx, @Nonnull Address sender, @Nonnull Integer integer);
     }
 
     /**
-     * Add a checker method for boxes that should be omitted when loading boxes from Explorer API
+     * Adds a checker method to {@link ExplorerApiUnspentLoader} for boxes that should be omitted
+     * when loading boxes from Explorer API
      */
     public abstract static class ExplorerApiWithCheckerLoader extends ExplorerApiUnspentLoader {
         protected abstract boolean canUseBox(InputBox box);

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/BlockchainContextImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/BlockchainContextImpl.java
@@ -159,51 +159,8 @@ public class BlockchainContextImpl extends BlockchainContextBase {
 
     @Override
     public CoveringBoxes getCoveringBoxesFor(Address address, long amountToSpend, List<ErgoToken> tokensToSpend) {
-        SelectTokensHelper tokensRemaining = new SelectTokensHelper(tokensToSpend);
-        Preconditions.checkArgument(amountToSpend > 0 ||
-            !tokensRemaining.areTokensCovered(), "amountToSpend or tokens to spend should be > 0");
-        ArrayList<InputBox> selectedCoveringBoxes = new ArrayList<>();
-        long remainingAmountToCover = amountToSpend;
-        int offset = 0;
-        while (true) {
-            List<InputBox> chunk = getUnspentBoxesFor(address, offset, DEFAULT_LIMIT_FOR_API);
-            for (InputBox boxCandidate : chunk) {
-                // on rare occasions, chunk can include entries that we already had received on a
-                // previous chunk page. We make sure we don't add any duplicate entries.
-                if (!isAlreadyAdded(selectedCoveringBoxes, boxCandidate)) {
-                    boolean usefulTokens = tokensRemaining.foundNewTokens(boxCandidate.getTokens());
-                    if (usefulTokens || remainingAmountToCover > 0) {
-                        selectedCoveringBoxes.add(boxCandidate);
-                        remainingAmountToCover -= boxCandidate.getValue();
-                    }
-                    if (remainingAmountToCover <= 0 && tokensRemaining.areTokensCovered())
-                        return new CoveringBoxes(amountToSpend, selectedCoveringBoxes);
-                }
-            }
-            // this chunk is not enough, go to the next (if any)
-            if (chunk.size() == 0) {
-                // this was the last chunk, but still remain to collect
-                assert remainingAmountToCover > 0 || !tokensRemaining.areTokensCovered();
-                // cannot satisfy the request, but still return cb, with cb.isCovered == false
-                return new CoveringBoxes(amountToSpend, selectedCoveringBoxes);
-            }
-            // step to next chunk
-            offset += DEFAULT_LIMIT_FOR_API;
-        }
-    }
-
-    /**
-     * @return true when boxCandidate is already added to selectedBoxes list
-     */
-    private boolean isAlreadyAdded(ArrayList<InputBox> selectedBoxes, InputBox boxCandidate) {
-        boolean alreadyAdded = false;
-        for (InputBox coveringBox : selectedBoxes) {
-            if (coveringBox.getId().equals(boxCandidate.getId())) {
-                alreadyAdded = true;
-                break;
-            }
-        }
-        return alreadyAdded;
+        return BoxOperations.getCoveringBoxesFor(amountToSpend, tokensToSpend,
+            page -> getUnspentBoxesFor(address, page * DEFAULT_LIMIT_FOR_API, DEFAULT_LIMIT_FOR_API));
     }
 }
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoNodeFacade.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoNodeFacade.java
@@ -101,6 +101,21 @@ public class ErgoNodeFacade extends ApiFacade {
             }
         });
     }
+    static public Transactions getUnconfirmedTransactions(
+            Retrofit r, int limit, int offset) throws ErgoClientException {
+        return execute(r, () -> {
+            Method method = TransactionsApi.class.getMethod("getUnconfirmedTransactions", Integer.class, Integer.class);
+            Response<Transactions> response = RetrofitUtil.<Transactions>invokeServiceMethod(r, method,
+                new Object[]{limit, offset}).execute();
+
+            if (!response.isSuccessful()) {
+                throw new ErgoClientException(response.code() + ": " +
+                    (response.errorBody() != null ? response.errorBody().string() : "Server returned error"), null);
+            } else {
+                return response.body();
+            }
+        });
+    }
 
 }
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoWalletImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoWalletImpl.java
@@ -1,12 +1,13 @@
 package org.ergoplatform.appkit.impl;
 
 import com.google.common.base.Preconditions;
-import org.ergoplatform.appkit.BoxOperations;
+
+import org.ergoplatform.appkit.BoxSelectorsJavaHelpers;
 import org.ergoplatform.appkit.ErgoWallet;
 import org.ergoplatform.appkit.InputBox;
 import org.ergoplatform.restapi.client.WalletBox;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -34,7 +35,7 @@ public class ErgoWalletImpl implements ErgoWallet {
             }).collect(Collectors.toList());
         }
 
-        List<InputBox> selected = BoxOperations.selectTop(_unspentBoxes, amountToSpend);
+        List<InputBox> selected = BoxSelectorsJavaHelpers.selectBoxes(_unspentBoxes, amountToSpend, Collections.emptyList());
         if (selected == null) return Optional.empty();
         return Optional.of(selected);
     }

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ExplorerAndPoolUnspentBoxesLoader.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ExplorerAndPoolUnspentBoxesLoader.java
@@ -1,6 +1,5 @@
 package org.ergoplatform.appkit.impl;
 
-import org.ergoplatform.appkit.BlockchainContext;
 import org.ergoplatform.appkit.BoxOperations;
 import org.ergoplatform.appkit.InputBox;
 import org.ergoplatform.restapi.client.ErgoTransaction;
@@ -10,6 +9,17 @@ import org.ergoplatform.restapi.client.Transactions;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * {@link BoxOperations.IUnspentBoxesLoader} implementation to be used with
+ * {@link BoxOperations#withInputBoxesLoader(BoxOperations.IUnspentBoxesLoader)}
+ * <p>
+ * Instead of the default implementation, this one fetches the mempool from the node connected to
+ * and blacklists the inputs so they aren't used for transactions made by {@link BoxOperations}
+ * methods.
+ * <p>
+ * Note that the mempool is fetched on object instantiation, so don't pass references around as
+ * the data will be outdated after some time.
+ */
 public class ExplorerAndPoolUnspentBoxesLoader extends BoxOperations.ExplorerApiWithCheckerLoader {
     private final List<String> unconfirmedSpentBoxesIds;
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ExplorerAndPoolUnspentBoxesLoader.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ExplorerAndPoolUnspentBoxesLoader.java
@@ -1,0 +1,34 @@
+package org.ergoplatform.appkit.impl;
+
+import org.ergoplatform.appkit.BlockchainContext;
+import org.ergoplatform.appkit.BoxOperations;
+import org.ergoplatform.appkit.InputBox;
+import org.ergoplatform.restapi.client.ErgoTransaction;
+import org.ergoplatform.restapi.client.ErgoTransactionInput;
+import org.ergoplatform.restapi.client.Transactions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExplorerAndPoolUnspentBoxesLoader extends BoxOperations.ExplorerApiWithCheckerLoader {
+    private final List<String> unconfirmedSpentBoxesIds;
+
+    public ExplorerAndPoolUnspentBoxesLoader(BlockchainContextImpl ctx) {
+        unconfirmedSpentBoxesIds = new ArrayList<>();
+
+        Transactions unconfirmedTransactions = ErgoNodeFacade.getUnconfirmedTransactions(ctx.getRetrofit(), 1000, 0);
+        for (ErgoTransaction unconfirmedTx : unconfirmedTransactions) {
+            for (ErgoTransactionInput txInput : unconfirmedTx.getInputs()) {
+                unconfirmedSpentBoxesIds.add(txInput.getBoxId());
+            }
+        }
+
+    }
+
+    @Override
+    protected boolean canUseBox(InputBox box) {
+        return !unconfirmedSpentBoxesIds.contains(box.getId().toString());
+    }
+}
+
+


### PR DESCRIPTION
BoxOperations get more and more complicated because the methods were static and overloaded to be used with prover, address or list of addresses and list of tokens or no list of tokens. To simplify this, I converted the methods to non-static with object fields holding the properties that can be set and have useful defaults when not set.

getCoveringBoxes method's main logic was moved from BlockChainContextImpl to BoxOperations because it makes more sense to have it there. The method is still available to call from BlockChainContextImpl, but marked Deprecated to make clients call it from BoxOperations.

BoxOperations.createProver methods are still static, but deprecated. These methods don't really fit into the class and are simple helper methods that doesn't need to be provided, so could be removed in the future.

This new structure makes it both simpler to call from clients (see changed tests) and simpler to enhance with more (optional) fields. This is used here to introduce a new field for the source to get the list of unspent boxes from. With this field, we can now override the default implementation that fetches the list of unspent boxes by address from Explorer API. 

This is done with `ExplorerAndPoolUnspentBoxesLoader`, an implementation that omits boxes that are already spent on mempool. This enables us to get a solution for ergoplatform/ergo-wallet-app#5 - moreover, there can be other implementations done for chained transaction support or completely different box selections.