### PR TITLE
Making  public get unsigne dtx for UnsignedTransactionImpl

### DIFF
--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/UnsignedTransactionImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/UnsignedTransactionImpl.java
@@ -23,7 +23,7 @@ public class UnsignedTransactionImpl implements UnsignedTransaction {
         _stateContext = stateContext;
     }
 
-    UnsignedErgoLikeTransaction getTx() {
+    public UnsignedErgoLikeTransaction getTx() {
         return _tx;
     }
 


### PR DESCRIPTION
👋  I am updating the playground with a SimulatedBlockchainContext. 

having this function as public would let me delete a lot of code.