### PR TITLE
Use ergo-wallet post-1627 with fixed BIP32 key derivation 

### DIFF
--- a/appkit/src/test/scala/org/ergoplatform/appkit/AddressSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/AddressSpec.scala
@@ -26,11 +26,11 @@ class AddressSpec extends PropSpec with Matchers with ScalaCheckDrivenPropertyCh
   }
 
   property("Address fromMnemonic") {
-    val addr = Address.fromMnemonic(NetworkType.TESTNET, mnemonic, SecretString.empty())
+    val addr = Address.fromMnemonic(NetworkType.TESTNET, mnemonic, SecretString.empty(), false)
     addr.toString shouldBe addrStr
     checkIsTestnetP2PKAddress(addr)
 
-    val addr2 = Address.fromMnemonic(NetworkType.MAINNET, mnemonic, SecretString.empty())
+    val addr2 = Address.fromMnemonic(NetworkType.MAINNET, mnemonic, SecretString.empty(), false)
     addr2.toString shouldNot be (addrStr)
 
     val addr3 = Address.fromErgoTree(addr.getErgoAddress.script, NetworkType.TESTNET)
@@ -62,12 +62,12 @@ class AddressSpec extends PropSpec with Matchers with ScalaCheckDrivenPropertyCh
   }
 
   property("Address createEip3Address") {
-    val addr = Address.fromMnemonic(NetworkType.MAINNET, mnemonic, SecretString.empty())
-    val firstEip3Addr = Address.createEip3Address(0, NetworkType.MAINNET, mnemonic, SecretString.empty())
+    val addr = Address.fromMnemonic(NetworkType.MAINNET, mnemonic, SecretString.empty(), false)
+    val firstEip3Addr = Address.createEip3Address(0, NetworkType.MAINNET, mnemonic, SecretString.empty(), false)
     firstEip3Addr.toString shouldBe firstEip3AddrStr
     addr.toString shouldNot be (firstEip3AddrStr)
 
-    val secondEip3Addr = Address.createEip3Address(1, NetworkType.MAINNET, mnemonic, SecretString.empty())
+    val secondEip3Addr = Address.createEip3Address(1, NetworkType.MAINNET, mnemonic, SecretString.empty(), false)
     secondEip3Addr.toString shouldBe secondEip3AddrStr
   }
 

--- a/appkit/src/test/scala/org/ergoplatform/appkit/ApiClientSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/ApiClientSpec.scala
@@ -17,7 +17,7 @@ class ApiClientSpec
         with HttpClientTesting {
 
   val seed = SecretString.create("abc")
-  val masterKey = JavaHelpers.seedToMasterKey(seed)
+  val masterKey = JavaHelpers.seedToMasterKey(seed, null, false)
   implicit val vs = ValidationRules.currentSettings
 
   property("parse ErgoTree") {

--- a/appkit/src/test/scala/org/ergoplatform/appkit/Bip32SerializationSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/Bip32SerializationSpec.scala
@@ -9,7 +9,7 @@ class Bip32SerializationSpec extends PropSpec with Matchers with ScalaCheckDrive
   with AppkitTesting {
 
   property("Serialization roundtrip") {
-    val masterKey = JavaHelpers.seedToMasterKey(mnemonic, SecretString.empty())
+    val masterKey = JavaHelpers.seedToMasterKey(mnemonic, SecretString.empty(), false)
     val xpubString = Bip32Serialization.serializeExtendedPublicKeyToHex(masterKey, NetworkType.MAINNET)
 
     an[IllegalArgumentException] shouldBe thrownBy {

--- a/appkit/src/test/scala/org/ergoplatform/appkit/MnemonicSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/MnemonicSpec.scala
@@ -38,7 +38,7 @@ class MnemonicSpec extends PropSpec with Matchers with ScalaCheckDrivenPropertyC
   }
 
   property("serializeExtendedPublicKey") {
-    val masterKey = JavaHelpers.seedToMasterKey(SecretString.create("lens stadium egg cage hollow noble gate belt impulse vicious middle endless angry buzz crack"), SecretString.empty())
+    val masterKey = JavaHelpers.seedToMasterKey(SecretString.create("lens stadium egg cage hollow noble gate belt impulse vicious middle endless angry buzz crack"), SecretString.empty(), false)
 
     Bip32Serialization.serializeExtendedPublicKeyToHex(masterKey, NetworkType.MAINNET) shouldBe "0488b21e04220c2217000000009216e49a70865823eff5381d6fd33ac96743af1f3051dc4cc8edd66a29a740860326cfc301b0c8d4d815ac721e0551304417e6133c2c9137f9f22c33895a3e1650"
   }

--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -204,7 +204,7 @@ class TxBuilderSpec extends PropSpec with Matchers
     assertExceptionThrown(
       ergoClient.execute { ctx: BlockchainContext =>
         ctx.newProverBuilder()
-          .withMnemonic(mnemonic, SecretString.empty())
+          .withMnemonic(mnemonic, SecretString.empty(), false)
           .withEip3Secret(0)
           .withEip3Secret(0) // attempt to add the same index
           .build()
@@ -216,14 +216,14 @@ class TxBuilderSpec extends PropSpec with Matchers
 
   private def testEip3Address(ctx: BlockchainContext, index: Int): Address = {
     Address.createEip3Address(index, ctx.getNetworkType,
-      mnemonic, SecretString.empty())
+      mnemonic, SecretString.empty(), false)
   }
 
   property("ErgoProverBuilder.withEip3Secret should pass secrets to the prover") {
     val ergoClient = createMockedErgoClient(MockData(Nil, Nil))
     ergoClient.execute { ctx: BlockchainContext =>
       val prover = ctx.newProverBuilder()
-        .withMnemonic(mnemonic, SecretString.empty())
+        .withMnemonic(mnemonic, SecretString.empty(), false)
         .withEip3Secret(0)
         .withEip3Secret(1)
         .build()

--- a/appkit/src/test/scala/org/ergoplatform/appkit/examples/ExampleScenarios.java
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/examples/ExampleScenarios.java
@@ -81,7 +81,7 @@ public class ExampleScenarios {
                                 .build())
                 .build();
         ErgoProverBuilder proverB = _ctx.newProverBuilder();
-        ErgoProver prover = proverB.withMnemonic(seedPhrase, null).build();
+        ErgoProver prover = proverB.withMnemonic(seedPhrase, null, false).build();
         SignedTransaction signed = prover.sign(tx);
         return signed;
     }

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ assemblyMergeStrategy in assembly := {
 lazy val allConfigDependency = "compile->compile;test->test"
 
 val sigmaStateVersion = "4.0.5"
-val ergoWalletVersion = "4.0.23"
+val ergoWalletVersion = "4.0.23-8-915d13af-SNAPSHOT"
 lazy val sigmaState = ("org.scorexfoundation" %% "sigma-state" % sigmaStateVersion).force()
     .exclude("ch.qos.logback", "logback-classic")
     .exclude("org.scorexfoundation", "scrypto")

--- a/common/src/main/java/org/ergoplatform/appkit/Address.java
+++ b/common/src/main/java/org/ergoplatform/appkit/Address.java
@@ -129,8 +129,8 @@ public class Address {
      */
     public static Address create(String base58Str) { return new Address(base58Str); }
 
-    public static Address fromMnemonic(NetworkType networkType, Mnemonic mnemonic) {
-        return fromMnemonic(networkType, mnemonic.getPhrase(), mnemonic.getPassword());
+    public static Address fromMnemonic(NetworkType networkType, Mnemonic mnemonic, Boolean usePre1627KeyDerivation) {
+        return fromMnemonic(networkType, mnemonic.getPhrase(), mnemonic.getPassword(), usePre1627KeyDerivation);
     }
 
     /**
@@ -142,10 +142,12 @@ public class Address {
      * @param mnemonic     mnemonic (e.g. 15 words) phrase
      * @param mnemonicPass optional (i.e. it can be empty) mnemonic password which is
      *                     necessary to know in order to restore the secrets
+     * @param usePre1627KeyDerivation use incorrect(previous) BIP32 derivation, expected to be true for new 
+     * wallets, and false for old pre-1627 wallets (see https://github.com/ergoplatform/ergo/issues/1627 for details)
      */
     public static Address fromMnemonic(
-        NetworkType networkType, SecretString mnemonic, SecretString mnemonicPass) {
-        ExtendedSecretKey masterKey = JavaHelpers.seedToMasterKey(mnemonic, mnemonicPass);
+            NetworkType networkType, SecretString mnemonic, SecretString mnemonicPass, Boolean usePre1627KeyDerivation) {
+        ExtendedSecretKey masterKey = JavaHelpers.seedToMasterKey(mnemonic, mnemonicPass, usePre1627KeyDerivation);
         DLogProtocol.ProveDlog pk = masterKey.publicImage();
         P2PKAddress p2pkAddress = JavaHelpers.createP2PKAddress(pk,
             networkType.networkPrefix);
@@ -163,13 +165,16 @@ public class Address {
      * @param mnemonic     mnemonic (e.g. 15 words) phrase
      * @param mnemonicPass optional (i.e. it can be empty) mnemonic password which is
      *                     necessary to know in order to restore the secrets
+     * @param usePre1627KeyDerivation use incorrect(previous) BIP32 derivation, expected to be true for new 
+     * wallets, and false for old pre-1627 wallets (see https://github.com/ergoplatform/ergo/issues/1627 for details)
      */
     public static Address createEip3Address(
         int index,
         NetworkType networkType,
         SecretString mnemonic,
-        SecretString mnemonicPass) {
-        ExtendedSecretKey rootSecret = JavaHelpers.seedToMasterKey(mnemonic, mnemonicPass);
+        SecretString mnemonicPass, 
+        Boolean usePre1627KeyDerivation) {
+        ExtendedSecretKey rootSecret = JavaHelpers.seedToMasterKey(mnemonic, mnemonicPass, usePre1627KeyDerivation);
 
         // Let's use "m/44'/429'/0'/0/index" path (this path is compliant with EIP-3 which
         // is BIP-44 for Ergo)

--- a/common/src/main/java/org/ergoplatform/appkit/JavaHelpers.scala
+++ b/common/src/main/java/org/ergoplatform/appkit/JavaHelpers.scala
@@ -380,10 +380,18 @@ object JavaHelpers {
     if (secretString == null || secretString.isEmpty) None else Some(secretString)
   }
 
-  def seedToMasterKey(seedPhrase: SecretString, pass: SecretString = null): ExtendedSecretKey = {
+  /**
+   * Create an extended secret key from mnemonic
+   *
+   * @param seedPhrase secret seed phrase to be used in prover for generating proofs.
+   * @param pass   password to protect secret seed phrase.
+   * @param usePre1627KeyDerivation use incorrect(previous) BIP32 derivation, expected to be true for new 
+   * wallets, and false for old pre-1627 wallets (see https://github.com/ergoplatform/ergo/issues/1627 for details)
+   */
+  def seedToMasterKey(seedPhrase: SecretString, pass: SecretString = null, usePre1627KeyDerivation: java.lang.Boolean): ExtendedSecretKey = {
     val passOpt = if (pass == null || pass.isEmpty()) None else Some(pass.toStringUnsecure)
     val seed = mnemonicToSeed(seedPhrase.toStringUnsecure, passOpt)
-    val masterKey = ExtendedSecretKey.deriveMasterKey(seed)
+    val masterKey = ExtendedSecretKey.deriveMasterKey(seed, usePre1627KeyDerivation)
     masterKey
   }
 

--- a/common/src/main/java/org/ergoplatform/appkit/SecretStorage.java
+++ b/common/src/main/java/org/ergoplatform/appkit/SecretStorage.java
@@ -60,8 +60,14 @@ public class SecretStorage {
         unlock(SecretString.create(encryptionPass));
     }
 
+    /**
+     * Initializes storage with the seed derived from an existing mnemonic phrase.
+     * @param mnemonic - mnemonic phase
+     * @param encryptionPass - encryption password
+     * @param usePre1627KeyDerivation - use incorrect(previous) BIP32 derivation, expected to be true for new wallets, and false for old pre-1627 wallets (see https://github.com/ergoplatform/ergo/issues/1627 for details)
+    */
     public static SecretStorage createFromMnemonicIn(
-            String secretDir, Mnemonic mnemonic, SecretString encryptionPassword) {
+            String secretDir, Mnemonic mnemonic, SecretString encryptionPassword, Boolean usePre1627KeyDerivation) {
         SecretStorageSettings settings = new SecretStorageSettings(secretDir, DEFAULT_SETTINGS);
 
         SecretString password = mnemonic.getPassword();
@@ -71,14 +77,14 @@ public class SecretStorage {
                 JavaHelpers.secretStringToOption(password != null ?
                     password.toInterface4JSecretString() : null),
                 encryptionPassword.toInterface4JSecretString(),
-                settings);
+                settings, usePre1627KeyDerivation);
 
         return new SecretStorage(jsonStorage);
     }
 
     public static SecretStorage createFromMnemonicIn(
-            String secretDir, Mnemonic mnemonic, String encryptionPassword) {
-        return createFromMnemonicIn(secretDir, mnemonic, SecretString.create(encryptionPassword));
+            String secretDir, Mnemonic mnemonic, String encryptionPassword, Boolean usePre1627KeyDerivation) {
+        return createFromMnemonicIn(secretDir, mnemonic, SecretString.create(encryptionPassword), usePre1627KeyDerivation);
     }
 
     public static SecretStorage loadFrom(String storageFileName) {

--- a/common/src/test/scala/org/ergoplatform/appkit/AppkitTestingCommon.scala
+++ b/common/src/test/scala/org/ergoplatform/appkit/AppkitTestingCommon.scala
@@ -22,5 +22,6 @@ trait AppkitTestingCommon {
   /** The address which corresponds to master key of the `mnemonic`. */
   val address = Address.fromMnemonic(
     NetworkType.MAINNET,
-    Mnemonic.create(mnemonic, SecretString.empty()))
+    Mnemonic.create(mnemonic, SecretString.empty()), 
+    false)
 }

--- a/common/src/test/scala/org/ergoplatform/appkit/SecretStorageSpec.scala
+++ b/common/src/test/scala/org/ergoplatform/appkit/SecretStorageSpec.scala
@@ -21,10 +21,10 @@ class SecretStorageSpec extends PropSpec with Matchers with ScalaCheckDrivenProp
     withNewStorageFor(mnemonicWithPassword, encryptionPass) { storage =>
       storage.unlock(encryptionPass)
       storage.isLocked shouldBe false
-      val addr = Address.fromMnemonic(NetworkType.TESTNET, mnemonicWithPassword)
+      val addr = Address.fromMnemonic(NetworkType.TESTNET, mnemonicWithPassword, false)
       val secret = storage.getSecret()
       secret should not be(null)
-      val expSecret = JavaHelpers.seedToMasterKey(mnemonicWithPassword.getPhrase, mnemonicWithPassword.getPassword)
+      val expSecret = JavaHelpers.seedToMasterKey(mnemonicWithPassword.getPhrase, mnemonicWithPassword.getPassword, false)
       expSecret shouldBe secret
       storage.getAddressFor(NetworkType.TESTNET) shouldBe addr
     }
@@ -56,7 +56,7 @@ class SecretStorageSpec extends PropSpec with Matchers with ScalaCheckDrivenProp
   def withNewStorageFor(mnemonic: Mnemonic, encryptionPass: String)(block: SecretStorage => Unit): Unit = {
     withTempDir { dir =>
       val dirPath = dir.getPath
-      val storage = SecretStorage.createFromMnemonicIn(dirPath, mnemonic, encryptionPass)
+      val storage = SecretStorage.createFromMnemonicIn(dirPath, mnemonic, encryptionPass, false)
       try {
         block(storage)
       }

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
@@ -105,9 +105,9 @@ public class BoxOperations {
     }
 
     @Deprecated
-    public static ErgoProver createProver(BlockchainContext ctx, Mnemonic mnemonic) {
+    public static ErgoProver createProver(BlockchainContext ctx, Mnemonic mnemonic, Boolean usePre1627KeyDerivation) {
         ErgoProver prover = ctx.newProverBuilder()
-            .withMnemonic(mnemonic.getPhrase(), mnemonic.getPassword())
+            .withMnemonic(mnemonic.getPhrase(), mnemonic.getPassword(), usePre1627KeyDerivation)
             .build();
         return prover;
     }

--- a/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProverBuilder.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProverBuilder.java
@@ -13,16 +13,20 @@ public interface ErgoProverBuilder {
      *
      * @param mnemonicPhrase secret seed phrase to be used in prover for generating proofs.
      * @param mnemonicPass   password to protect secret seed phrase.
+     * @param usePre1627KeyDerivation use incorrect(previous) BIP32 derivation, expected to be true for new 
+     * wallets, and false for old pre-1627 wallets (see https://github.com/ergoplatform/ergo/issues/1627 for details)
      */
-    ErgoProverBuilder withMnemonic(SecretString mnemonicPhrase, SecretString mnemonicPass);
+    ErgoProverBuilder withMnemonic(SecretString mnemonicPhrase, SecretString mnemonicPass, Boolean usePre1627KeyDerivation);
 
     /**
      * Configure this builder to use the given mnemonic when building a new prover.
      *
      * @param mnemonic {@link Mnemonic} instance containing secret seed phrase to be used in prover for
      *                 generating proofs.
+     * @param usePre1627KeyDerivation use incorrect(previous) BIP32 derivation, expected to be true for new 
+     * wallets, and false for old pre-1627 wallets (see https://github.com/ergoplatform/ergo/issues/1627 for details)
      */
-    ErgoProverBuilder withMnemonic(Mnemonic mnemonic);
+    ErgoProverBuilder withMnemonic(Mnemonic mnemonic, Boolean usePre1627KeyDerivation);
 
     /**
      * Configure this builder to derive the new EIP-3 secret key with the given index.

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoProverBuilderImpl.scala
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoProverBuilderImpl.scala
@@ -20,13 +20,14 @@ class ErgoProverBuilderImpl(_ctx: BlockchainContextBase) extends ErgoProverBuild
   private val _dLogSecrets = new util.ArrayList[DLogProtocol.DLogProverInput]
 
   override def withMnemonic(mnemonicPhrase: SecretString,
-                            mnemonicPass: SecretString): ErgoProverBuilder = {
-    _masterKey = JavaHelpers.seedToMasterKey(mnemonicPhrase, mnemonicPass)
+                            mnemonicPass: SecretString,
+                            usePre1627KeyDerivation: java.lang.Boolean): ErgoProverBuilder = {
+    _masterKey = JavaHelpers.seedToMasterKey(mnemonicPhrase, mnemonicPass, usePre1627KeyDerivation)
     this
   }
 
-  override def withMnemonic(mnemonic: Mnemonic): ErgoProverBuilder =
-    withMnemonic(mnemonic.getPhrase, mnemonic.getPassword)
+  override def withMnemonic(mnemonic: Mnemonic, usePre1627KeyDerivation: java.lang.Boolean): ErgoProverBuilder =
+    withMnemonic(mnemonic.getPhrase, mnemonic.getPassword, usePre1627KeyDerivation)
 
   override def withEip3Secret(index: Int): ErgoProverBuilder = {
     require(_masterKey != null, s"Mnemonic is not specified, use withMnemonic method.")


### PR DESCRIPTION
Ref https://github.com/ergoplatform/ergo/issues/1627

This PR updates `ergo-wallet` to the version published in https://github.com/ergoplatform/ergo/pull/1636 and exposes usePre1627KeyDerivation option in relevant API in `Address`, `SecretStorage`, etc.
