### PR TITLE
BoxOperations: Consider amount for change box

### DIFF
--- a/appkit/src/test/scala/org/ergoplatform/appkit/MockedBoxesLoader.java
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/MockedBoxesLoader.java
@@ -1,0 +1,37 @@
+package org.ergoplatform.appkit;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Mocked loader for BoxOperations
+ */
+public class MockedBoxesLoader implements BoxOperations.IUnspentBoxesLoader {
+
+    private final List<InputBox> mockBoxes;
+
+    public MockedBoxesLoader(List<InputBox> mockBoxes) {
+        this.mockBoxes = mockBoxes;
+    }
+
+    @Override
+    public void prepare(@Nonnull BlockchainContext ctx, List<Address> addresses, long grossAmount, @Nonnull List<ErgoToken> tokensToSpend) {
+
+    }
+
+    @Override
+    public void prepareForAddress(Address address) {
+
+    }
+
+    @Nonnull
+    @Override
+    public List<InputBox> loadBoxesPage(@Nonnull BlockchainContext ctx, @Nonnull Address address, @Nonnull Integer page) {
+        if (page == 0) {
+            return mockBoxes;
+        } else
+            return Collections.emptyList();
+    }
+}

--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -364,7 +364,7 @@ class TxBuilderSpec extends PropSpec with Matchers
 
       // send 1 ERG
       val amountToSend = 1000L * 1000 * 1000
-      val pkContract = new ErgoTreeContract(recipient.getErgoAddress.script)
+      val pkContract = new ErgoTreeContract(recipient.getErgoAddress.script, recipient.getNetworkType)
 
       val senders = Arrays.asList(storage.getAddressFor(NetworkType.MAINNET))
 

--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -353,6 +353,43 @@ class TxBuilderSpec extends PropSpec with Matchers
 
   }
 
+  property("consider changebox amount") {
+    val ergoClient = createMockedErgoClient(data)
+
+    ergoClient.execute { ctx: BlockchainContext =>
+      val storage = SecretStorage.loadFrom("storage/E2.json")
+      storage.unlock("abc")
+
+      val recipient = address
+
+      // send 1 ERG
+      val amountToSend = 1000L * 1000 * 1000
+      val pkContract = new ErgoTreeContract(recipient.getErgoAddress.script)
+
+      val senders = Arrays.asList(storage.getAddressFor(NetworkType.MAINNET))
+
+      // first box: 1 ERG + tx fee + token that will cause a change
+      val input1 = ctx.newTxBuilder.outBoxBuilder
+        .value(amountToSend + Parameters.MinFee)
+        .contract(pkContract)
+        .tokens(new ErgoToken(mockTxId, 2))
+        .build().convertToInputWith(mockTxId, 0)
+      // second box: enough ERG for the change box
+      val input2 = ctx.newTxBuilder.outBoxBuilder
+        .value(amountToSend)
+        .contract(pkContract)
+        .build().convertToInputWith(mockTxId, 1)
+
+      val operations = BoxOperations.createForSenders(senders).withAmountToSpend(amountToSend)
+        .withInputBoxesLoader(new MockedBoxesLoader(Arrays.asList(input1, input2)))
+      val inputsSelected = operations.loadTop(ctx)
+
+      // both boxes should be selected
+      inputsSelected.size() shouldBe 2
+    }
+
+  }
+
   property("Special tx building cases") {
     val ergoClient = createMockedErgoClient(MockData(Nil, Nil))
     ergoClient.execute { ctx: BlockchainContext =>

--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -376,7 +376,7 @@ class TxBuilderSpec extends PropSpec with Matchers
         .build().convertToInputWith(mockTxId, 0)
       // second box: enough ERG for the change box
       val input2 = ctx.newTxBuilder.outBoxBuilder
-        .value(amountToSend)
+        .value(Parameters.MinFee)
         .contract(pkContract)
         .build().convertToInputWith(mockTxId, 1)
 

--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -381,6 +381,7 @@ class TxBuilderSpec extends PropSpec with Matchers
         .build().convertToInputWith(mockTxId, 1)
 
       val operations = BoxOperations.createForSenders(senders).withAmountToSpend(amountToSend)
+        .withTokensToSpend(Arrays.asList(new ErgoToken(mockTxId, 1)))
         .withInputBoxesLoader(new MockedBoxesLoader(Arrays.asList(input1, input2)))
       val inputsSelected = operations.loadTop(ctx)
 

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ assemblyMergeStrategy in assembly := {
 lazy val allConfigDependency = "compile->compile;test->test"
 
 val sigmaStateVersion = "4.0.5"
-val ergoWalletVersion = "4.0.23"
+val ergoWalletVersion = "4.0.23-24-70d87086-SNAPSHOT"
 lazy val sigmaState = ("org.scorexfoundation" %% "sigma-state" % sigmaStateVersion).force()
     .exclude("ch.qos.logback", "logback-classic")
     .exclude("org.scorexfoundation", "scrypto")

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ assemblyMergeStrategy in assembly := {
 lazy val allConfigDependency = "compile->compile;test->test"
 
 val sigmaStateVersion = "4.0.5"
-val ergoWalletVersion = "4.0.23-24-70d87086-SNAPSHOT"
+val ergoWalletVersion = "4.0.23-25-38c4b5fb-SNAPSHOT"
 lazy val sigmaState = ("org.scorexfoundation" %% "sigma-state" % sigmaStateVersion).force()
     .exclude("ch.qos.logback", "logback-classic")
     .exclude("org.scorexfoundation", "scrypto")

--- a/common/src/main/java/org/ergoplatform/appkit/SelectTokensHelper.java
+++ b/common/src/main/java/org/ergoplatform/appkit/SelectTokensHelper.java
@@ -6,7 +6,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Helper class to keep track of amount of tokens to spend and amount of tokens already found
+ * Helper class to keep track of amount of tokens to spend and tokens already covered by boxes.
+ * Used to determine if more and which boxes need to be selected, and if a change box is needed.
  */
 public class SelectTokensHelper {
     private final HashMap<String, Long> tokensLeft;
@@ -44,16 +45,17 @@ public class SelectTokensHelper {
     }
 
     /**
-     * Marks the given tokens as needed, subtracting the amount from the remaining amount of
-     * tokens to find.
-     * Also updates if a change box is needed
+     * Marks the given tokens as selected, subtracting the amount values from the remaining amount
+     * of tokens needed to fulfill the initial tokens to spend.
+     * Also keeps track if a change box is needed in case we selected to many tokens, see
+     * {@link #isChangeBoxNeeded()}
      */
-    public void useTokens(Iterable<ErgoToken> foundTokens) {
-        for (ErgoToken foundToken : foundTokens) {
-            String tokenId = foundToken.getId().toString();
+    public void useTokens(Iterable<ErgoToken> selectedTokens) {
+        for (ErgoToken selectedToken : selectedTokens) {
+            String tokenId = selectedToken.getId().toString();
             if (tokensLeft.containsKey(tokenId)) {
                 Long currentValue = tokensLeft.get(tokenId);
-                long newValue = currentValue - foundToken.getValue();
+                long newValue = currentValue - selectedToken.getValue();
                 tokensLeft.put(tokenId, newValue);
                 if (newValue < 0) {
                     changeBoxNeeded = true;
@@ -64,6 +66,9 @@ public class SelectTokensHelper {
         }
     }
 
+    /**
+     * @return true if currently selected tokens can fulfill the initial tokens to spend
+     */
     public boolean areTokensCovered() {
         boolean success = true;
         for (Long value : tokensLeft.values()) {
@@ -86,6 +91,10 @@ public class SelectTokensHelper {
         return result;
     }
 
+    /**
+     * @return true if a change box is needed. This is the case if more tokens were selected
+     * than needed to spend.
+     */
     public boolean isChangeBoxNeeded() {
         return changeBoxNeeded;
     }

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
@@ -171,7 +171,7 @@ public class BoxOperations {
                 changeBoxConsidered,
                 page -> inputBoxesLoader.loadBoxesPage(ctx, sender, page));
 
-            // change box needed but not considered yet?
+            // when a change box needed it needs some extra nanoergs to be sent
             if (!changeBoxConsidered && addressUnspentBoxes.isChangeBoxNeeded()) {
                 changeBoxConsidered = true;
                 remainingAmount = remainingAmount + CHANGE_BOX_NANOERG;
@@ -268,7 +268,8 @@ public class BoxOperations {
      *
      * @param amountToSpend       amount of NanoErgs to be covered
      * @param tokensToSpend       ErgoToken to spent
-     * @param changeBoxConsidered true if change box is already considered by amountToSpend
+     * @param changeBoxConsidered true if CHANGE_BOX_NANOERG amount for a change box is already
+     *                            included in amountToSpend and does not need to be added any more
      * @param inputBoxesLoader    method returning paged sets of InputBoxes, see above
      * @return a new instance of {@link CoveringBoxes} set
      */

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
@@ -28,6 +28,8 @@ public class BoxOperations {
     private long feeAmount = MinFee;
     private IUnspentBoxesLoader inputBoxesLoader = new ExplorerApiUnspentLoader();
 
+    private static final long CHANGE_BOX_NANOERG = MinFee;
+
     private BoxOperations(List<Address> senders, @Nullable ErgoProver senderProver) {
         this.senders = senders;
         this.senderProver = senderProver;
@@ -95,7 +97,7 @@ public class BoxOperations {
     }
 
     /**
-     * @param inputBoxesSource to use for {@link #getCoveringBoxesFor(long, List, Function)}
+     * @param inputBoxesSource to use for {@link #getCoveringBoxesFor(long, List, boolean, Function)}
      *                         See {@link IUnspentBoxesLoader for more information}
      *                         Default is {@link ExplorerApiUnspentLoader}
      */
@@ -157,6 +159,7 @@ public class BoxOperations {
         List<InputBox> unspentBoxes = new ArrayList<>();
         long grossAmount = amountToSpend + feeAmount;
         long remainingAmount = grossAmount;
+        boolean changeBoxConsidered = false;
         SelectTokensHelper tokensHelper = new SelectTokensHelper(tokensToSpend);
         List<ErgoToken> remainingTokens = tokensToSpend;
 
@@ -164,11 +167,19 @@ public class BoxOperations {
 
         for (Address sender : senders) {
             inputBoxesLoader.prepareForAddress(sender);
-            CoveringBoxes unspent = getCoveringBoxesFor(remainingAmount, remainingTokens,
+            CoveringBoxes addressUnspentBoxes = getCoveringBoxesFor(remainingAmount, remainingTokens,
+                changeBoxConsidered,
                 page -> inputBoxesLoader.loadBoxesPage(ctx, sender, page));
-            for (InputBox b : unspent.getBoxes()) {
+
+            // change box needed but not considered yet?
+            if (!changeBoxConsidered && addressUnspentBoxes.isChangeBoxNeeded()) {
+                changeBoxConsidered = true;
+                remainingAmount = remainingAmount + CHANGE_BOX_NANOERG;
+            }
+
+            for (InputBox b : addressUnspentBoxes.getBoxes()) {
                 unspentBoxes.add(b);
-                tokensHelper.foundNewTokens(b.getTokens());
+                tokensHelper.useTokens(b.getTokens());
                 remainingAmount -= b.getValue();
                 if (remainingAmount <= 0 && tokensHelper.areTokensCovered()) {
                     // collected enough boxes to cover the amount
@@ -255,13 +266,15 @@ public class BoxOperations {
      * - returning an empty list means the source of input boxes is drained and no further page will
      *   be loaded
      *
-     * @param amountToSpend    amount of NanoErgs to be covered
-     * @param tokensToSpend    ErgoToken to spent
-     * @param inputBoxesLoader method returning paged sets of InputBoxes, see above
+     * @param amountToSpend       amount of NanoErgs to be covered
+     * @param tokensToSpend       ErgoToken to spent
+     * @param changeBoxConsidered true if change box is already considered by amountToSpend
+     * @param inputBoxesLoader    method returning paged sets of InputBoxes, see above
      * @return a new instance of {@link CoveringBoxes} set
      */
     public static CoveringBoxes getCoveringBoxesFor(long amountToSpend,
                                                     List<ErgoToken> tokensToSpend,
+                                                    boolean changeBoxConsidered,
                                                     Function<Integer, List<InputBox>> inputBoxesLoader) {
         SelectTokensHelper tokensRemaining = new SelectTokensHelper(tokensToSpend);
         Preconditions.checkArgument(amountToSpend > 0 ||
@@ -275,13 +288,22 @@ public class BoxOperations {
                 // on rare occasions, chunk can include entries that we already had received on a
                 // previous chunk page. We make sure we don't add any duplicate entries.
                 if (!isAlreadyAdded(selectedCoveringBoxes, boxCandidate)) {
-                    boolean usefulTokens = tokensRemaining.foundNewTokens(boxCandidate.getTokens());
+                    boolean usefulTokens = tokensRemaining.areTokensNeeded(boxCandidate.getTokens());
                     if (usefulTokens || remainingAmountToCover > 0) {
                         selectedCoveringBoxes.add(boxCandidate);
                         remainingAmountToCover -= boxCandidate.getValue();
+                        tokensRemaining.useTokens(boxCandidate.getTokens());
+
+                        // if we haven't accounted for a change box so far, but now a change box is
+                        // needed, we have to search for a little more amount to cover the change
+                        if (!changeBoxConsidered && tokensRemaining.isChangeBoxNeeded()) {
+                            changeBoxConsidered = true;
+                            remainingAmountToCover = remainingAmountToCover + CHANGE_BOX_NANOERG;
+                            amountToSpend = amountToSpend + CHANGE_BOX_NANOERG;
+                        }
                     }
                     if (remainingAmountToCover <= 0 && tokensRemaining.areTokensCovered())
-                        return new CoveringBoxes(amountToSpend, selectedCoveringBoxes);
+                        return new CoveringBoxes(amountToSpend, selectedCoveringBoxes, tokensToSpend, changeBoxConsidered);
                 }
             }
             // this chunk is not enough, go to the next (if any)
@@ -289,7 +311,7 @@ public class BoxOperations {
                 // this was the last chunk, but still remain to collect
                 assert remainingAmountToCover > 0 || !tokensRemaining.areTokensCovered();
                 // cannot satisfy the request, but still return cb, with cb.isCovered == false
-                return new CoveringBoxes(amountToSpend, selectedCoveringBoxes);
+                return new CoveringBoxes(amountToSpend, selectedCoveringBoxes, tokensToSpend, changeBoxConsidered);
             }
             // step to next chunk
             page++;
@@ -337,13 +359,13 @@ public class BoxOperations {
         /**
          * @param ctx     {@link BlockchainContext} to work with, if needed
          * @param address p2pk address unspent boxes list should be fetched for
-         * @param integer page that should be loaded, 0-based integer
+         * @param page    page that should be loaded, 0-based integer
          * @return a list of InputBox to select from. First items are preferred to be selected.
          * Returning an empty list means the source of input boxes is drained and no further
          * page should be loaded
          */
         @Nonnull
-        List<InputBox> loadBoxesPage(@Nonnull BlockchainContext ctx, @Nonnull Address address, @Nonnull Integer integer);
+        List<InputBox> loadBoxesPage(@Nonnull BlockchainContext ctx, @Nonnull Address address, @Nonnull Integer page);
     }
 
     /**

--- a/lib-api/src/main/java/org/ergoplatform/appkit/CoveringBoxes.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/CoveringBoxes.java
@@ -4,18 +4,22 @@ import java.util.List;
 
 /**
  * Represents a collection of boxes covering the given amount of NanoErgs to spend.
- * If the amount is not covered in full, then isCovered() returns false. Tokens are not taken into
- * account.
+ * If the amount is not covered in full, then isCovered() returns false.
  * Thus, this class allows to represent partial coverage, which is useful to collect boxes
  * in many steps.
  */
 public class CoveringBoxes {
     private final long _amountToSpend;
     private final List<InputBox> _boxes;
+    private final List<ErgoToken> tokensToSpend;
+    private final boolean changeBoxNeeded;
 
-    public CoveringBoxes(long amountToSpend, List<InputBox> boxes) {
+    public CoveringBoxes(long amountToSpend, List<InputBox> boxes,
+                         List<ErgoToken> tokensToSpend, boolean changeBoxNeeded) {
         _amountToSpend = amountToSpend;
         _boxes = boxes;
+        this.tokensToSpend = tokensToSpend;
+        this.changeBoxNeeded = changeBoxNeeded;
     }
 
     /** The amount covered by the boxes in this set. */
@@ -33,5 +37,12 @@ public class CoveringBoxes {
     /** Returns a list of boxes stored in this set. */
     public List<InputBox> getBoxes() {
         return _boxes;
+    }
+
+    /**
+     * @return true if a change box is needed to spend the selected boxes
+     */
+    public boolean isChangeBoxNeeded() {
+        return changeBoxNeeded;
     }
 }

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/BlockchainContextImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/BlockchainContextImpl.java
@@ -163,7 +163,7 @@ public class BlockchainContextImpl extends BlockchainContextBase {
 
     @Override
     public CoveringBoxes getCoveringBoxesFor(Address address, long amountToSpend, List<ErgoToken> tokensToSpend) {
-        return BoxOperations.getCoveringBoxesFor(amountToSpend, tokensToSpend,
+        return BoxOperations.getCoveringBoxesFor(amountToSpend, tokensToSpend, false,
             page -> getUnspentBoxesFor(address, page * DEFAULT_LIMIT_FOR_API, DEFAULT_LIMIT_FOR_API));
     }
 }


### PR DESCRIPTION
When we have tokens in selected inboxes that shouldn't be sent, a change box is needed to return the tokens to the sending address. That means that a small amount of ERG is needed on top of the actual amount to send which must be considered when selecting boxes.

This change adds the ability to BoxOperations to account for a change box amount and an accompanying test case. However, the test case files although BoxOperations is now correctly selecting the two boxes of the test case. This is due to `DefaultBoxSelector` ignoring the second, needed box which needs to be fixed in ergo-wallet.

Follow-up to #103 