### PR TITLE
BoxOperations: provide method preparing TransactionBuilder with fee, inputs and change address

### DIFF
--- a/appkit/src/test/scala/org/ergoplatform/appkit/AnonymousAccessSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/AnonymousAccessSpec.scala
@@ -119,12 +119,12 @@ object DhtUtils {
        |  proveDHTuple(groupGenerator, g_y, g_x, g_xy)    // for alice
        |}""".stripMargin);
 
-    val dhtBoxCreationTx = BoxOperations.createForProver(sender).withAmountToSpend(amountToSend).putToContractTx(ctx, contract)
+    val dhtBoxCreationTx = BoxOperations.createForProver(sender, ctx).withAmountToSpend(amountToSend).putToContractTx(contract)
     dhtBoxCreationTx
   }
 
   def spendDhtBox(ctx: BlockchainContext, g_y: GroupElement, g_xy: GroupElement, sender: ErgoProver, dhtBox: InputBox, receiver: Address): SignedTransaction = {
-    val tx = BoxOperations.createForSender(sender.getAddress).buildTxWithTransactionBuilder(ctx, { txB: UnsignedTransactionBuilder =>
+    val tx = BoxOperations.createForSender(sender.getAddress, ctx).buildTxWithDefaultInputs { txB: UnsignedTransactionBuilder =>
       val outBox = txB.outBoxBuilder
         .value(dhtBox.getValue)
         .contract(new ErgoTreeContract(receiver.getErgoAddress.script, receiver.getNetworkType))
@@ -133,7 +133,7 @@ object DhtUtils {
 
       txB.outputs(outBox)
       txB
-    })
+    }
 
     sender.sign(tx)
   }

--- a/appkit/src/test/scala/org/ergoplatform/appkit/AnonymousAccessSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/AnonymousAccessSpec.scala
@@ -124,7 +124,7 @@ object DhtUtils {
   }
 
   def spendDhtBox(ctx: BlockchainContext, g_y: GroupElement, g_xy: GroupElement, sender: ErgoProver, dhtBox: InputBox, receiver: Address): SignedTransaction = {
-    val tx = BoxOperations.createForSender(sender.getAddress).buildTxWithTransactionBuilder(ctx, { txB =>
+    val tx = BoxOperations.createForSender(sender.getAddress).buildTxWithTransactionBuilder(ctx, { txB: UnsignedTransactionBuilder =>
       val outBox = txB.outBoxBuilder
         .value(dhtBox.getValue)
         .contract(new ErgoTreeContract(receiver.getErgoAddress.script))

--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -254,8 +254,8 @@ class TxBuilderSpec extends PropSpec with Matchers
 
       val recipient = senderProver.getEip3Addresses.get(1)
       val amountToSend = 1000000
-      val signed = BoxOperations.createForProver(senderProver).withAmountToSpend(amountToSend)
-        .send(ctx, recipient)
+      val signed = BoxOperations.createForProver(senderProver, ctx).withAmountToSpend(amountToSend)
+        .send(recipient)
       assert(signed != null)
     }
   }
@@ -273,8 +273,8 @@ class TxBuilderSpec extends PropSpec with Matchers
       val pkContract = new ErgoTreeContract(recipient.getErgoAddress.script, recipient.getNetworkType)
 
       val senders = Arrays.asList(storage.getAddressFor(NetworkType.MAINNET))
-      val unsigned = BoxOperations.createForSenders(senders).withAmountToSpend(amountToSend)
-        .putToContractTxUnsigned(ctx, pkContract)
+      val unsigned = BoxOperations.createForSenders(senders, ctx).withAmountToSpend(amountToSend)
+        .putToContractTxUnsigned(pkContract)
 
       val prover = ctx.newProverBuilder.build // prover without secrets
       val reduced = prover.reduce(unsigned, 0)
@@ -340,9 +340,9 @@ class TxBuilderSpec extends PropSpec with Matchers
         val pkContract = new ErgoTreeContract(recipient.getErgoAddress.script, recipient.getNetworkType)
 
         val senders = Arrays.asList(storage.getAddressFor(NetworkType.MAINNET))
-        val unsigned = BoxOperations.createForSenders(senders).withAmountToSpend(amountToSend)
+        val unsigned = BoxOperations.createForSenders(senders, ctx).withAmountToSpend(amountToSend)
           .withInputBoxesLoader(new ExplorerAndPoolUnspentBoxesLoader())
-          .putToContractTxUnsigned(ctx, pkContract)
+          .putToContractTxUnsigned(pkContract)
 
         val prover = ctx.newProverBuilder.build // prover without secrets
         val reduced = prover.reduce(unsigned, 0)
@@ -380,10 +380,10 @@ class TxBuilderSpec extends PropSpec with Matchers
         .contract(pkContract)
         .build().convertToInputWith(mockTxId, 1)
 
-      val operations = BoxOperations.createForSenders(senders).withAmountToSpend(amountToSend)
+      val operations = BoxOperations.createForSenders(senders, ctx).withAmountToSpend(amountToSend)
         .withTokensToSpend(Arrays.asList(new ErgoToken(mockTxId, 1)))
         .withInputBoxesLoader(new MockedBoxesLoader(Arrays.asList(input1, input2)))
-      val inputsSelected = operations.loadTop(ctx)
+      val inputsSelected = operations.loadTop()
 
       // both boxes should be selected
       inputsSelected.size() shouldBe 2


### PR DESCRIPTION
When I prepared the examples for Ergo Pay, I found myself writing repeating code preparing a transaction with inputs, fee, change box, only differing in the way how outputs are built.

I switched to use a helper method for Ergo Pay example to get rid of the repeating code, and I think it is useful to have it on Appkit for others to use. When found useful and merged, we can use it for adding more logic depending on it like minting a new token.