### PR TITLE
Make verifySignature static on ErgoProver

### DIFF
--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -77,13 +77,13 @@ class TxBuilderSpec extends PropSpec with Matchers
       val signedMessage = proverA.signMessage(proverA.getP2PKAddress,
         msg.getBytes, HintsBag.empty)
 
-      proverA.verifySignature(proverA.getP2PKAddress,
+      Signature.verifySignature(proverA.getP2PKAddress,
         msg.getBytes, signedMessage) shouldBe true
 
-      proverB.verifySignature(proverA.getP2PKAddress,
+      Signature.verifySignature(proverA.getP2PKAddress,
         msg.getBytes, signedMessage) shouldBe true
 
-      proverB.verifySignature(proverB.getP2PKAddress,
+      Signature.verifySignature(proverB.getP2PKAddress,
         msg.getBytes, signedMessage) shouldBe false
       }
     }

--- a/common/src/main/java/org/ergoplatform/appkit/Signature.java
+++ b/common/src/main/java/org/ergoplatform/appkit/Signature.java
@@ -14,7 +14,7 @@ public class Signature {
     /**
      * Verifies a signature on given (arbitrary) message for a given public key.
      *
-     * @param sigmaTree     public key (represented as a tree)
+     * @param sigmaTree     public key (represented as a sigma proposition tree)
      * @param message       message to verify
      * @param signature signature for the message
      * @return whether signature is valid or not
@@ -24,7 +24,7 @@ public class Signature {
     }
 
     /**
-     * Verifies a signature on given (arbitrary) message for a
+     * Verifies a signature on given (arbitrary) message
      * using an address' public key.
      *
      * @param addr          address whose public key will be used to verify message

--- a/common/src/main/java/org/ergoplatform/appkit/Signature.java
+++ b/common/src/main/java/org/ergoplatform/appkit/Signature.java
@@ -1,0 +1,38 @@
+package org.ergoplatform.appkit;
+
+import org.ergoplatform.P2PKAddress;
+import org.ergoplatform.ErgoLikeInterpreter;
+
+import sigmastate.Values.SigmaBoolean;
+import sigmastate.eval.CompiletimeIRContext;
+
+public class Signature {
+    private Signature() {
+        // prevent instantiation
+    }
+
+    /**
+     * Verifies a signature on given (arbitrary) message for a given public key.
+     *
+     * @param sigmaTree     public key (represented as a tree)
+     * @param message       message to verify
+     * @param signature signature for the message
+     * @return whether signature is valid or not
+     */
+    public static boolean verifySignature(SigmaBoolean sigmaTree, byte[] message, byte[] signature) {
+        return new ErgoLikeInterpreter((new CompiletimeIRContext())).verifySignature(sigmaTree, message, signature);
+    }
+
+    /**
+     * Verifies a signature on given (arbitrary) message for a
+     * using an address' public key.
+     *
+     * @param addr          address whose public key will be used to verify message
+     * @param message       message to verify
+     * @param signature signature for the message
+     * @return whether signature is valid or not
+     */
+    public static boolean verifySignature(P2PKAddress addr, byte[] message, byte[] signature) {
+        return new ErgoLikeInterpreter((new CompiletimeIRContext())).verifySignature(addr.pubkey(), message, signature);
+    }
+}

--- a/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/ErgoProver.java
@@ -74,6 +74,7 @@ public interface ErgoProver {
      * @param message message to sign
      * @param hintsBag additional hints for a signer (useful for distributed signing)
      * @return signed message
+     * @see Signature#verifySignature(SigmaBoolean, byte[], byte[])
      */
     byte[] signMessage(SigmaBoolean sigmaTree, byte[] message, HintsBag hintsBag);
 
@@ -84,32 +85,12 @@ public interface ErgoProver {
      * @param message message to sign
      * @param hintsBag additional hints for a signer (useful for distributed signing)
      * @return signed message
+     * @see Signature#verifySignature(P2PKAddress, byte[], byte[])
      */
     byte[] signMessage(P2PKAddress addr, byte[] message, HintsBag hintsBag);
 
     ReducedTransaction reduce(UnsignedTransaction tx, int baseCost);
 
     SignedTransaction signReduced(ReducedTransaction tx, int baseCost);
-
-    /**
-     * Verifies a signature on given (arbitrary) message for a given public key.
-     *
-     * @param sigmaTree public key (represented as a tree)
-     * @param message message to verify
-     * @param signedMessage signature for the message
-     * @return whether signature is valid or not
-     */
-    boolean verifySignature(SigmaBoolean sigmaTree, byte[] message, byte[] signedMessage);
-
-    /**
-     * Verifies a signature on given (arbitrary) message for a 
-     * using an address' public key.
-     *
-     * @param addr address whose public key will be used to verify message
-     * @param message message to verify
-     * @param signedMessage signature for the message
-     * @return whether signature is valid or not
-     */
-    boolean verifySignature(P2PKAddress addr, byte[] message, byte[] signedMessage);
 }
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoProverImpl.scala
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ErgoProverImpl.scala
@@ -69,13 +69,5 @@ class ErgoProverImpl(_ctx: BlockchainContextBase,
     new SignedTransactionImpl(_ctx, signed, cost)
   }
 
-  override def verifySignature(sigmaTree: SigmaBoolean, message: Array[Byte], signedMessage: Array[Byte]): Boolean = {
-    _prover.verifySignature(sigmaTree, message, signedMessage)
-  }
-
-  override def verifySignature(addr: P2PKAddress, message: Array[Byte], signedMessage: Array[Byte]): Boolean = {
-    _prover.verifySignature(addr.pubkey, message, signedMessage)
-  }
-
 }
 


### PR DESCRIPTION
verifying a signature is independant from actual prover and doesn't need any secrets, so this changes the code towards being usable without constructing a prover holding secrets.