### PR TITLE
Fix Explorer API getApiV1Blocks

### DIFF
--- a/java-client-generated/src/main/java/org/ergoplatform/explorer/client/DefaultApi.java
+++ b/java-client-generated/src/main/java/org/ergoplatform/explorer/client/DefaultApi.java
@@ -4,6 +4,7 @@ import retrofit2.Call;
 import retrofit2.http.*;
 
 import org.ergoplatform.explorer.client.model.Balance;
+import org.ergoplatform.explorer.client.model.BlockInfo;
 import org.ergoplatform.explorer.client.model.BlockSummary;
 import org.ergoplatform.explorer.client.model.BoxQuery;
 import org.ergoplatform.explorer.client.model.EpochParameters;
@@ -103,7 +104,7 @@ public interface DefaultApi {
    * @return Call&lt;ItemsA&gt;
    */
   @GET("api/v1/blocks")
-  Call<ItemsA> getApiV1Blocks(
+  Call<Items<BlockInfo>> getApiV1Blocks(
         @retrofit2.http.Query("offset") Integer offset                ,     @retrofit2.http.Query("limit") Integer limit                ,     @retrofit2.http.Query("sortBy") String sortBy                ,     @retrofit2.http.Query("sortDirection") String sortDirection                
   );
 

--- a/java-client-generated/src/test/java/org/ergoplatform/explorer/client/DefaultApiTest.java
+++ b/java-client-generated/src/test/java/org/ergoplatform/explorer/client/DefaultApiTest.java
@@ -2,6 +2,7 @@ package org.ergoplatform.explorer.client;
 
 import org.ergoplatform.ApiTestBase;
 import org.ergoplatform.explorer.client.model.Balance;
+import org.ergoplatform.explorer.client.model.BlockInfo;
 import org.ergoplatform.explorer.client.model.BlockSummary;
 import org.ergoplatform.explorer.client.model.BoxQuery;
 import org.ergoplatform.explorer.client.model.EpochParameters;
@@ -86,7 +87,7 @@ public class DefaultApiTest extends ApiTestBase {
         Integer limit = 10;
         String sortBy = null;
         String sortDirection = null;
-        ItemsA response = api.getApiV1Blocks(offset, limit, sortBy, sortDirection).execute().body();
+        Items<BlockInfo> response = api.getApiV1Blocks(offset, limit, sortBy, sortDirection).execute().body();
         assertTrue(response.getItems().size() > 0);
     }
 


### PR DESCRIPTION
This fixes wrong return type for Explorer's getApiV1Blocks