### PR TITLE
Fix UnsignedTransactionImpl reporting wrong outputs

### DIFF
--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -182,6 +182,7 @@ class TxBuilderSpec extends PropSpec with Matchers
       val prover = ctx.newProverBuilder().build()
       val signed = prover.sign(unsigned)
 
+      unsigned.getOutputs.size() shouldBe 2
       signed.getOutputsToSpend.size() shouldBe 2
     }
   }
@@ -281,6 +282,7 @@ class TxBuilderSpec extends PropSpec with Matchers
       reduced should not be(null)
       reduced.getInputBoxesIds.size() shouldBe unsigned.getInputs.size()
       reduced.getInputBoxesIds shouldBe unsigned.getInputBoxesIds
+      reduced.getOutputs.size() shouldBe unsigned.getOutputs.size()
       reduced
     }
 
@@ -429,7 +431,9 @@ class TxBuilderSpec extends PropSpec with Matchers
         .build()
 
       val prover = ctx.newProverBuilder().build()
-      prover.sign(unsigned)
+      val signed = prover.sign(unsigned)
+
+      unsigned.getOutputs.size() shouldBe signed.getOutputsToSpend.size()
     }
   }
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/UnsignedTransactionBuilderImpl.scala
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/UnsignedTransactionBuilderImpl.scala
@@ -138,7 +138,7 @@ class UnsignedTransactionBuilderImpl(val _ctx: BlockchainContextImpl) extends Un
     )
 
     val stateContext = createErgoLikeStateContext
-    new UnsignedTransactionImpl(txWithExtensions, boxesToSpend, dataInputBoxes, outputCandidates, changeAddress, stateContext, _ctx)
+    new UnsignedTransactionImpl(txWithExtensions, boxesToSpend, dataInputBoxes, changeAddress, stateContext, _ctx)
   }
 
   private def createErgoLikeStateContext: ErgoLikeStateContext = new ErgoLikeStateContext() {

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/UnsignedTransactionImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/UnsignedTransactionImpl.java
@@ -14,11 +14,13 @@ import org.ergoplatform.wallet.protocol.context.ErgoLikeStateContext;
 import java.util.ArrayList;
 import java.util.List;
 
+import scala.collection.JavaConversions;
+
 public class UnsignedTransactionImpl implements UnsignedTransaction {
     private final UnsignedErgoLikeTransaction _tx;
     private List<ExtendedInputBox> _boxesToSpend;
     private List<ErgoBox> _dataBoxes;
-    private List<ErgoBoxCandidate> _outputs;
+    private List<ErgoBox> _outputs;
     private ErgoAddress _changeAddress;
     private ErgoLikeStateContext _stateContext;
     private BlockchainContextImpl _ctx;
@@ -26,11 +28,11 @@ public class UnsignedTransactionImpl implements UnsignedTransaction {
 
     public UnsignedTransactionImpl(
         UnsignedErgoLikeTransaction tx, List<ExtendedInputBox> boxesToSpend,
-        List<ErgoBox> dataBoxes, List<ErgoBoxCandidate> outputs, ErgoAddress changeAddress, ErgoLikeStateContext stateContext, BlockchainContextImpl ctx) {
+        List<ErgoBox> dataBoxes, ErgoAddress changeAddress, ErgoLikeStateContext stateContext, BlockchainContextImpl ctx) {
         _tx = tx;
         _boxesToSpend = boxesToSpend;
         _dataBoxes = dataBoxes;
-        _outputs = outputs;
+        _outputs = JavaConversions.seqAsJavaList(_tx.outputs());
         _changeAddress = changeAddress;
         _stateContext = stateContext;
         _ctx = ctx;


### PR DESCRIPTION
UnsignedTransactionImpl did not take into account that output boxes are completed during transaction building. It only reported the actual outboxes added by the client, but omitted fee and changebox. 