### PR TITLE
Added Node Wallet support to BlockchainDataSource, along with a simple BoxLoader

### DIFF
--- a/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainDataSource.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainDataSource.java
@@ -72,6 +72,31 @@ public interface BlockchainDataSource {
     List<InputBox> getUnconfirmedUnspentBoxesFor(Address address, int offset, int limit);
 
     /**
+     * Get all unspent boxes in the current node wallet, without unconfirmed boxes
+     * @return List of input boxes representing all known
+     */
+    List<InputBox> getUnspentWalletBoxes();
+    /**
+     * Get all unspent boxes in the current node wallet, without unconfirmed boxes
+     * @param minConfirmations Minimum number of confirmations for a box to be included in the returned list
+     * @param minInclusionHeight Minimum creation height for a box to be included in the returned list
+     * @return List of input boxes representing all known
+     */
+    List<InputBox> getUnspentWalletBoxes(int minConfirmations, int minInclusionHeight);
+
+    /**
+     * Get all unspent boxes in the current node wallet, including unconfirmed boxes from the MemPool
+     * @return List of all unspent boxes in this node's current wallet
+     */
+    List<InputBox> getUnconfirmedUnspentWalletBoxes();
+    /**
+     * Get all unspent boxes in the current node wallet, including unconfirmed boxes from the MemPool
+     * @param minInclusionHeight Minimum creation height for a box to be included in the returned list
+     * @return List of all unspent boxes in this node's current wallet
+     */
+    List<InputBox> getUnconfirmedUnspentWalletBoxes(int minInclusionHeight);
+
+    /**
      * @return unconfirmed transactions from mempool
      */
     List<Transaction> getUnconfirmedTransactions(int offset, int limit);

--- a/lib-api/src/main/java/org/ergoplatform/appkit/NodeWalletUnspentBoxesLoader.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/NodeWalletUnspentBoxesLoader.java
@@ -1,0 +1,57 @@
+package org.ergoplatform.appkit;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * {@link BoxOperations.IUnspentBoxesLoader} implementation to be used with
+ * {@link BoxOperations#withInputBoxesLoader(BoxOperations.IUnspentBoxesLoader)}
+ * <p>
+ * Pre-loads all boxes from node wallet, then returns pages of boxes from the master list.
+ * May optionally allow boxes to be grabbed from the MemPool as well.
+ */
+public class NodeWalletUnspentBoxesLoader implements BoxOperations.IUnspentBoxesLoader {
+    private List<InputBox> allBoxes;
+    private boolean withMemPoolBoxes = false;
+
+    public NodeWalletUnspentBoxesLoader withMemPoolBoxes(boolean withMemPoolBoxes) {
+        this.withMemPoolBoxes = withMemPoolBoxes;
+        return this;
+    }
+
+    public List<InputBox> getAllBoxes() {
+        return allBoxes;
+    }
+
+    @Override
+    public void prepare(@Nonnull BlockchainContext ctx, List<Address> addresses, long grossAmount, @Nonnull List<ErgoToken> tokensToSpend) {
+        BlockchainDataSource dataSource = ctx.getDataSource();
+        if(withMemPoolBoxes)
+            allBoxes = dataSource.getUnconfirmedUnspentWalletBoxes();
+        else
+            allBoxes = dataSource.getUnspentWalletBoxes();
+    }
+
+    @Override
+    public void prepareForAddress(Address address) {
+        // Do nothing, actual address used will be from node wallet anyway
+        // Maybe interface should be changed to be more abstracted? Or a separate interface is needed?
+    }
+
+    @Nonnull
+    @Override
+    public List<InputBox> loadBoxesPage(@Nonnull BlockchainContext ctx, @Nonnull Address sender, @Nonnull Integer page) {
+        int currentOffset = ctx.DEFAULT_LIMIT_FOR_API * page;
+        int pageEndIndex  = currentOffset + ctx.DEFAULT_LIMIT_FOR_API;
+
+        if(currentOffset > allBoxes.size())
+            return allBoxes.subList(0,0); // Return empty list in case current offset is greater than ending index
+
+        if(pageEndIndex > allBoxes.size())
+            pageEndIndex = allBoxes.size(); // Shorten returned list to last index in case pageEndIndex is greater than size of list
+
+        return allBoxes.subList(currentOffset, pageEndIndex);
+    }
+}
+
+


### PR DESCRIPTION
Would like a review, because implementing IUnspentBoxesLoader feels wrong due to needing an Address. Also no way to paginate boxes from the WalletAPI as far as I can tell, so had to pre-load all boxes which may be inefficient. I used to use `ctx.getWallet` quite a bit to get wallet boxes, so would like this functionality to still be supported some how.