### PR TITLE
BlockchainContextImpl use only full headers to build transactions

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -4,3 +4,5 @@
 - RestApiErgoClient.createWithProxy method replaced by RestApiErgoClient.createWithHttpClientBuilder
   To create an instance using a proxy, use createWithHttpClientBuilder with a Builder created with
   new OkHttpClient.Builder().proxy(...)
+- BlockchainDataSource.getLastBlockHeaders added parameter onlyFullHeaders - use false for old behaviour
+- BlockchainDataSource.getParameters might return a cached object - use a new data source to force reload

--- a/appkit/src/test/resources/mockwebserver/node_responses/response_NodeInfo.json
+++ b/appkit/src/test/resources/mockwebserver/node_responses/response_NodeInfo.json
@@ -3,7 +3,7 @@
   "name": "mainnet-seed-node-frankfurt",
   "appVersion": "3.1.4",
   "network": "mainnet",
-  "fullHeight": 123414,
+  "fullHeight": 123413,
   "headersHeight": 123414,
   "bestFullHeaderId": "8d87fd4a7372877462ff7ecb52a6063207ffda2689f4de3254cc9a2877953f4f",
   "previousFullHeaderId": "0895a4a3dddbfd8faee6d9f957c42b64ee328714221809ad20d8fa4d036e1bf9",

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainDataSource.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainDataSource.java
@@ -8,17 +8,20 @@ import java.util.List;
  */
 public interface BlockchainDataSource {
     /**
-     * @return blockchain parameters this data source is working with
+     * @return blockchain parameters this data source is working with. The returned value
+     *         might be cached by the data source as it is not subject to change frequently
      */
     BlockchainParameters getParameters();
 
     /**
      * Get the last headers objects, sorted by descending order
      *
-     * @param count count of a wanted block headers (required)
+     * @param count           count of a wanted block headers (required)
+     * @param onlyFullHeaders restrict returned list to full headers. If set to true, amount of
+     *                        returned block headers might be less than "count"
      * @return List&lt;BlockHeader&gt;
      */
-    List<BlockHeader> getLastBlockHeaders(int count);
+    List<BlockHeader> getLastBlockHeaders(int count, boolean onlyFullHeaders);
 
     /**
      * Get box contents for a box by a unique identifier for use as an Input
@@ -58,6 +61,7 @@ public interface BlockchainDataSource {
      * @return a requested chunk of boxes owned by the address
      */
     List<InputBox> getUnspentBoxesFor(Address address, int offset, int limit);
+
     /**
      * Get unspent boxes owned by the given address starting from the given offset up to
      * the given limit (basically one page of the boxes), restricted to mempool.

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/BlockchainContextImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/BlockchainContextImpl.java
@@ -35,8 +35,10 @@ public class BlockchainContextImpl extends BlockchainContextBase {
             NetworkType networkType) {
         super(networkType);
 
+        List<BlockHeader> headers = dataSource.getLastBlockHeaders(NUM_LAST_HEADERS, true);
+        // access parameters after fetching the block headers can make use of caching parameters
+        // in DataSource implementations
         BlockchainParameters blockchainParameters = dataSource.getParameters();
-        List<BlockHeader> headers = dataSource.getLastBlockHeaders(NUM_LAST_HEADERS);
 
         if (blockchainParameters.getNetworkType() != networkType) {
             throw new IllegalArgumentException("Network type of NodeInfo does not match given networkType - "

--- a/lib-impl/src/test/java/org/ergoplatform/appkit/impl/BlockchainContextImplTest.java
+++ b/lib-impl/src/test/java/org/ergoplatform/appkit/impl/BlockchainContextImplTest.java
@@ -94,7 +94,7 @@ public class BlockchainContextImplTest extends ApiTestBase {
         }
 
         @Override
-        public List<BlockHeader> getLastBlockHeaders(int count) {
+        public List<BlockHeader> getLastBlockHeaders(int count, boolean onlyFullHeaders) {
             return null;
         }
 


### PR DESCRIPTION
Users were reporting the following error when submitting transactions to the node:

>  "error" : 400,
>  "reason" : "bad.request",
>  "detail" : "Malformed transaction: Transaction outputs should have creationHeight not exceeding block height.  731399 <= >727346 is not true

Underlying cause is the node getting out of sync and having fullHeight and headersHeight diverge.
To minimize affected users in situations that are not as extreme as quoted above (sometimes the difference is only a single block), this PR changes BlockchainContextImpl to only use blocks known to fullHeight as preheaders for new transactions.
For this, BlockchainDataSource parameter has been added.