### PR TITLE
Fix Mainnet and Testnet Address being equal

### DIFF
--- a/appkit/src/test/scala/org/ergoplatform/appkit/AddressSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/AddressSpec.scala
@@ -33,6 +33,7 @@ class AddressSpec extends PropSpec with Matchers with ScalaCheckDrivenPropertyCh
     checkIsTestnetP2PKAddress(addr)
 
     val addr2 = Address.fromMnemonic(NetworkType.MAINNET, mnemonic, SecretString.empty())
+    addr2 shouldNot be (addr)
     addr2.toString shouldNot be (addrStr)
 
     val addr3 = Address.fromErgoTree(addr.getErgoAddress.script, NetworkType.TESTNET)

--- a/common/src/main/java/org/ergoplatform/appkit/Address.java
+++ b/common/src/main/java/org/ergoplatform/appkit/Address.java
@@ -21,6 +21,8 @@ import special.sigma.GroupElement;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.Objects;
+
 public class Address {
     private final String _base58String;
     private final byte[] _addrBytes;
@@ -245,13 +247,14 @@ public class Address {
 
     @Override
     public int hashCode() {
-        return _address.hashCode();
+        return Objects.hashCode(_address.hashCode(), _address.networkPrefix());
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof Address) {
-            return _address.equals(((Address) obj)._address);
+            return _address.networkPrefix() == ((Address) obj)._address.networkPrefix()
+                && _address.equals(((Address) obj)._address);
         }
         return false;
     }


### PR DESCRIPTION
This commit fixes that Testnet and Mainnet addresses were reported as equal by `Address.equals()`.