### PR TITLE
Address: add fromErgoValue and toErgoValue methods

### DIFF
--- a/appkit/src/test/scala/org/ergoplatform/appkit/AddressSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/AddressSpec.scala
@@ -53,6 +53,8 @@ class AddressSpec extends PropSpec with Matchers with ScalaCheckDrivenPropertyCh
     val addr = new Address(ergoAddr)
     addr.isP2S shouldBe true
     addr.getErgoAddress.script.constants.size shouldBe 1
+
+    Address.fromPropositionBytes(NetworkType.TESTNET, addr.toPropositionBytes) shouldBe addr
   }
 
   property("construct P2SH Address") {
@@ -61,6 +63,8 @@ class AddressSpec extends PropSpec with Matchers with ScalaCheckDrivenPropertyCh
     val addr = new Address(ergoAddr)
     addr.isP2S shouldBe false
     addr.isP2PK shouldBe false
+
+    Address.fromPropositionBytes(NetworkType.TESTNET, addr.toPropositionBytes) shouldBe addr
   }
 
   property("Address createEip3Address") {
@@ -71,17 +75,21 @@ class AddressSpec extends PropSpec with Matchers with ScalaCheckDrivenPropertyCh
 
     val secondEip3Addr = Address.createEip3Address(1, NetworkType.MAINNET, mnemonic, SecretString.empty())
     secondEip3Addr.toString shouldBe secondEip3AddrStr
+
+    Address.fromPropositionBytes(NetworkType.MAINNET, addr.toPropositionBytes) shouldBe addr
   }
 
   property("create Address from ErgoTree with DHT") {
     val tree = "100207036ba5cfbc03ea2471fdf02737f64dbcd58c34461a7ec1e586dcd713dacbf89a120400d805d601db6a01ddd6027300d603b2a5730100d604e4c672030407d605e4c672030507eb02ce7201720272047205ce7201720472027205"
     implicit val encoder: ErgoAddressEncoder = ErgoAddressEncoder.apply(NetworkType.MAINNET.networkPrefix);
     val ergoTree = ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(Base16.decode(tree).get)
-    val addr = Address.fromErgoTree(ergoTree, NetworkType.MAINNET).getErgoAddress
+    val addr = Address.fromErgoTree(ergoTree, NetworkType.MAINNET)
     val addr2 = encoder.fromProposition(ergoTree).get
     val addr3 = encoder.fromProposition(ergoTree.proposition).get
-    addr shouldBe addr2
-    addr shouldBe addr3
+    val addr4 = Address.fromPropositionBytes(NetworkType.MAINNET, Base16.decode(tree).get)
+    addr.getErgoAddress shouldBe addr2
+    addr.getErgoAddress shouldBe addr3
+    addr shouldBe addr4
   }
 
   property("Address address from xpub key") {

--- a/common/src/main/java/org/ergoplatform/appkit/Address.java
+++ b/common/src/main/java/org/ergoplatform/appkit/Address.java
@@ -1,5 +1,7 @@
 package org.ergoplatform.appkit;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import org.bouncycastle.math.ec.custom.sec.SecP256K1Point;
 import org.ergoplatform.ErgoAddress;
 import org.ergoplatform.ErgoAddressEncoder;
@@ -16,10 +18,9 @@ import scorex.util.encode.Base58;
 import sigmastate.Values;
 import sigmastate.basics.DLogProtocol;
 import sigmastate.eval.CostingSigmaDslBuilder$;
+import sigmastate.serialization.ErgoTreeSerializer;
 import sigmastate.utils.Helpers;
 import special.sigma.GroupElement;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class Address {
     private final String _base58String;
@@ -131,6 +132,14 @@ public class Address {
     }
 
     /**
+     * @return this addresses ErgoTree's proposition bytes. Use this to store this address
+     * on Box registers.
+     */
+    public byte[] toPropositionBytes() {
+        return getErgoAddress().script().bytes();
+    }
+
+    /**
      * @return true if this address is a SigmaBoolean
      */
     public boolean isSigmaBoolean() {
@@ -158,6 +167,20 @@ public class Address {
      * @return Address instance decoded from string
      */
     public static Address create(String base58Str) { return new Address(base58Str); }
+
+    /**
+     * Creates address from given ergovalue containing an ErgoTree proposition bytes.
+     * Use this to convert a box register containing an ErgoTree into its address.
+     *
+     * @param networkType      mainnet or testnet network
+     * @param propositionBytes ErgoTree proposition bytes
+     */
+    public static Address fromPropositionBytes(NetworkType networkType, byte[] propositionBytes) {
+        return new ErgoTreeContract(
+            ErgoTreeSerializer.DefaultSerializer().deserializeErgoTree(propositionBytes),
+            networkType
+        ).toAddress();
+    }
 
     public static Address fromMnemonic(NetworkType networkType, Mnemonic mnemonic) {
         return fromMnemonic(networkType, mnemonic.getPhrase(), mnemonic.getPassword());


### PR DESCRIPTION
Address.fromErgoValue and Address.toErgoValue come in handy when storing contracts as proposition bytes to boxes.