### PR TITLE
Release action: Skip tests when building fat jar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
 
       - name: Build fat jar
-        run: sbt clean assembly
+        run: sbt 'set test in assembly := {}' clean assembly
       - name: Upload release binaries
         uses: alexellis/upload-assets@0.2.2
         env:


### PR DESCRIPTION
This skips the tests when building fat jar in release action, as they already run before for sonatype release.