### PR TITLE
Adding conversions from SigmaBoolean to Address

### DIFF
--- a/appkit/src/test/scala/org/ergoplatform/appkit/AddressSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/AddressSpec.scala
@@ -44,6 +44,9 @@ class AddressSpec extends PropSpec with Matchers with ScalaCheckDrivenPropertyCh
 
     val addr5 = Address.fromSigmaBoolean(addr.getSigmaBoolean, NetworkType.MAINNET)
     addr5 shouldBe addr2
+
+    val addr6 = new SigmaProp(ErgoValue.of(addr.getSigmaBoolean).getValue).toAddress(NetworkType.TESTNET)
+    addr6 shouldBe addr
   }
 
   property("Address from ErgoAddress") {

--- a/appkit/src/test/scala/org/ergoplatform/appkit/AddressSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/AddressSpec.scala
@@ -38,6 +38,12 @@ class AddressSpec extends PropSpec with Matchers with ScalaCheckDrivenPropertyCh
 
     val addr3 = Address.fromErgoTree(addr.getErgoAddress.script, NetworkType.TESTNET)
     addr3 shouldBe addr
+
+    val addr4 = SigmaProp.createFromAddress(addr).toAddress(NetworkType.TESTNET)
+    addr4 shouldBe addr
+
+    val addr5 = Address.fromSigmaBoolean(addr.getSigmaBoolean, NetworkType.MAINNET)
+    addr5 shouldBe addr2
   }
 
   property("Address from ErgoAddress") {

--- a/common/src/main/java/org/ergoplatform/appkit/Address.java
+++ b/common/src/main/java/org/ergoplatform/appkit/Address.java
@@ -263,6 +263,11 @@ public class Address {
         return new Address(ergoAddress);
     }
 
+    public static Address fromSigmaBoolean(Values.SigmaBoolean sigmaBoolean, NetworkType networkType) {
+        Values.ErgoTree ergoTree = JavaHelpers$.MODULE$.toErgoTree(sigmaBoolean);
+        return fromErgoTree(ergoTree, networkType);
+    }
+
     @Override
     public String toString() {
         return _address.toString();

--- a/common/src/main/java/org/ergoplatform/appkit/JavaHelpers.scala
+++ b/common/src/main/java/org/ergoplatform/appkit/JavaHelpers.scala
@@ -352,6 +352,8 @@ object JavaHelpers {
     }
   }
 
+  def toErgoTree(sigmaBoolean: SigmaBoolean): ErgoTree = ErgoTree.fromSigmaBoolean(sigmaBoolean)
+
   def getStateDigest(tree: AvlTree): Array[Byte] = {
     tree.digest.toArray
   }

--- a/common/src/main/java/org/ergoplatform/appkit/SigmaProp.java
+++ b/common/src/main/java/org/ergoplatform/appkit/SigmaProp.java
@@ -23,6 +23,10 @@ public class SigmaProp {
         return Iso.isoSigmaBooleanToByteArray().to(sigmaBoolean);
     }
 
+    public Address toAddress(NetworkType networkType) {
+        return Address.fromSigmaBoolean(sigmaBoolean, networkType);
+    }
+
     /**
      * @return SigmaProp equal to the one that was serialized with {@link #toBytes()}
      */

--- a/common/src/main/java/org/ergoplatform/appkit/SigmaProp.java
+++ b/common/src/main/java/org/ergoplatform/appkit/SigmaProp.java
@@ -12,6 +12,10 @@ public class SigmaProp {
         this.sigmaBoolean = sigmaBoolean;
     }
 
+    public SigmaProp(special.sigma.SigmaProp sigmaProp) {
+        this(JavaHelpers.SigmaDsl().toSigmaBoolean(sigmaProp));
+    }
+
     public Values.SigmaBoolean getSigmaBoolean() {
         return sigmaBoolean;
     }

--- a/java-client-generated/src/test/java/org/ergoplatform/explorer/client/DefaultApiTest.java
+++ b/java-client-generated/src/test/java/org/ergoplatform/explorer/client/DefaultApiTest.java
@@ -21,6 +21,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.OkHttpClient;
 
 /**
  * API tests for DefaultApi
@@ -30,7 +33,12 @@ public class DefaultApiTest extends ApiTestBase {
 
     @Before
     public void setup() {
-        api = new ExplorerApiClient("https://api.ergoplatform.com")
+        int timeout = 180;
+        ExplorerApiClient apiClient = new ExplorerApiClient("https://api.ergoplatform.com");
+        apiClient.configureFromOkClientBuilder(new OkHttpClient.Builder().connectTimeout(timeout, TimeUnit.SECONDS)
+            .readTimeout(timeout, TimeUnit.SECONDS)
+            .writeTimeout(timeout, TimeUnit.SECONDS));
+        api = apiClient
             .createService(DefaultApi.class);
     }
 
@@ -266,7 +274,7 @@ public class DefaultApiTest extends ApiTestBase {
         HashMap<String, String> regs = new HashMap<>();
         regs.put("R4", "{\"serializedValue\": \"0702472963123ce32c057907c7a7268bc09f45d9ca57819d3327b9e7497d7b1cc347\"}");
         BoxQuery body = new BoxQuery()
-           .registers(regs);
+            .registers(regs);
         Integer offset = 0;
         Integer limit = 10;
         // TODO: clarify how to use this method


### PR DESCRIPTION
Adding convenience methods to convert from sigmastate SigmaProp to appkit's SigmaProp, and from SigmaBoolean to address.

This is needed when there is a SigmaProp saved in a box register.