### PR TITLE
BoxOperations: property to restrict the amount of input boxes

### DIFF
--- a/common/src/main/java/org/ergoplatform/appkit/InputBoxesSelectionException.java
+++ b/common/src/main/java/org/ergoplatform/appkit/InputBoxesSelectionException.java
@@ -1,11 +1,30 @@
 package org.ergoplatform.appkit;
 
+import java.util.List;
 import java.util.Map;
 
 public class InputBoxesSelectionException extends RuntimeException {
 
     public InputBoxesSelectionException(String message) {
         super(message);
+    }
+
+    /**
+     * Thrown when a max amount of input boxes is set to be found, but it does not cover
+     * the amount of ERG and/or tokens to send.
+     */
+    public static class InputBoxLimitExceededException extends InputBoxesSelectionException {
+
+        public final long remainingAmount;
+        public final List<ErgoToken> remainingTokens;
+        public final int boxLimit;
+
+        public InputBoxLimitExceededException(String message, long remainingAmount, List<ErgoToken> remainingTokens, int boxLimit) {
+            super(message);
+            this.remainingAmount = remainingAmount;
+            this.remainingTokens = remainingTokens;
+            this.boxLimit = boxLimit;
+        }
     }
 
     /**

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
@@ -28,6 +28,7 @@ public class BoxOperations {
     private long feeAmount = MinFee;
     private IUnspentBoxesLoader inputBoxesLoader = new ExplorerApiUnspentLoader();
     private BoxAttachment attachment;
+    private int maxInputBoxesToSelect = 0;
 
     private static final long CHANGE_BOX_NANOERG = MinFee;
 
@@ -115,6 +116,21 @@ public class BoxOperations {
         return this;
     }
 
+    public int getMaxInputBoxesToSelect() {
+        return maxInputBoxesToSelect;
+    }
+
+    /**
+     * @param maxInputBoxesToSelect if set greater than 0, {@link #loadTop()} will only select
+     *                              up to this number of input boxes to satisfy ERG and token amount
+     *                              needed and throws an {@link org.ergoplatform.appkit.InputBoxesSelectionException.InputBoxLimitExceededException}
+     *                              otherwise
+     */
+    public BoxOperations withMaxInputBoxesToSelect(int maxInputBoxesToSelect) {
+        this.maxInputBoxesToSelect = maxInputBoxesToSelect;
+        return this;
+    }
+
     /**
      * @param message message to be set for outboxes as {@link BoxAttachmentPlainText}
      */
@@ -171,6 +187,7 @@ public class BoxOperations {
     public long getFeeAmount() {
         return feeAmount;
     }
+
     @Deprecated
     public static ErgoProver createProver(BlockchainContext ctx, Mnemonic mnemonic) {
         ErgoProver prover = ctx.newProverBuilder()
@@ -214,6 +231,10 @@ public class BoxOperations {
      * list.
      * The list is then used to select covering boxes.
      *
+     * The method respects a max amount of boxes to be selected set by {@link #withMaxInputBoxesToSelect(int)}.
+     * If this limit is exceeded, a {@link org.ergoplatform.appkit.InputBoxesSelectionException.InputBoxLimitExceededException}
+     * is thrown and no further boxes are loaded.
+     *
      * @return a list of boxes covering the given amount
      */
     public List<InputBox> loadTop() {
@@ -230,7 +251,9 @@ public class BoxOperations {
             inputBoxesLoader.prepareForAddress(sender);
             CoveringBoxes addressUnspentBoxes = getCoveringBoxesFor(remainingAmount, remainingTokens,
                 changeBoxConsidered,
-                page -> inputBoxesLoader.loadBoxesPage(ctx, sender, page));
+                page -> inputBoxesLoader.loadBoxesPage(ctx, sender, page),
+                (maxInputBoxesToSelect <= 0) ? 0 : Math.max(1, maxInputBoxesToSelect - unspentBoxes.size())
+            );
 
             // when a change box needed it needs some extra nanoergs to be sent
             if (!changeBoxConsidered && addressUnspentBoxes.isChangeBoxNeeded()) {
@@ -378,6 +401,14 @@ public class BoxOperations {
                                                     List<ErgoToken> tokensToSpend,
                                                     boolean changeBoxConsidered,
                                                     Function<Integer, List<InputBox>> inputBoxesLoader) {
+        return getCoveringBoxesFor(amountToSpend, tokensToSpend, changeBoxConsidered, inputBoxesLoader, 0);
+    }
+
+    private static CoveringBoxes getCoveringBoxesFor(long amountToSpend,
+                                                     List<ErgoToken> tokensToSpend,
+                                                     boolean changeBoxConsidered,
+                                                     Function<Integer, List<InputBox>> inputBoxesLoader,
+                                                     int maxBoxesToSelect) {
         SelectTokensHelper tokensRemaining = new SelectTokensHelper(tokensToSpend);
         Preconditions.checkArgument(amountToSpend > 0 ||
             !tokensRemaining.areTokensCovered(), "amountToSpend or tokens to spend should be > 0");
@@ -406,6 +437,17 @@ public class BoxOperations {
                     }
                     if (remainingAmountToCover <= 0 && tokensRemaining.areTokensCovered())
                         return new CoveringBoxes(amountToSpend, selectedCoveringBoxes, tokensToSpend, changeBoxConsidered);
+
+                    else if (maxBoxesToSelect > 0 && selectedCoveringBoxes.size() >= maxBoxesToSelect) {
+                        List<ErgoToken> remainingTokenList = tokensRemaining.getRemainingTokenList();
+                        throw new InputBoxesSelectionException.InputBoxLimitExceededException(
+                            "Input box limit exceeded, could not cover " + remainingAmountToCover +
+                                " nanoERG and " + remainingTokenList.size() + " tokens.",
+                            remainingAmountToCover,
+                            remainingTokenList,
+                            maxBoxesToSelect
+                        );
+                    }
                 }
             }
             // this chunk is not enough, go to the next (if any)

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
@@ -125,6 +125,8 @@ public class BoxOperations {
      *                              up to this number of input boxes to satisfy ERG and token amount
      *                              needed and throws an {@link org.ergoplatform.appkit.InputBoxesSelectionException.InputBoxLimitExceededException}
      *                              otherwise
+     *                              if set to <= 0 (or not set), there is no input box restriction
+     *                              checked by loadTop.
      */
     public BoxOperations withMaxInputBoxesToSelect(int maxInputBoxesToSelect) {
         this.maxInputBoxesToSelect = maxInputBoxesToSelect;
@@ -438,6 +440,7 @@ public class BoxOperations {
                     if (remainingAmountToCover <= 0 && tokensRemaining.areTokensCovered())
                         return new CoveringBoxes(amountToSpend, selectedCoveringBoxes, tokensToSpend, changeBoxConsidered);
 
+                    // check the maxBoxToSelect restriction, if it is set
                     else if (maxBoxesToSelect > 0 && selectedCoveringBoxes.size() >= maxBoxesToSelect) {
                         List<ErgoToken> remainingTokenList = tokensRemaining.getRemainingTokenList();
                         throw new InputBoxesSelectionException.InputBoxLimitExceededException(


### PR DESCRIPTION
Recently several miners with small payout boxes expressed problems in the support channels sending ERG caused by too many input boxes. 

This expresses in the typical error indications:
* Error when submitting the transaction "too high cost"
* Very long loading time
* Timeout exceptions connecting Explorer and/or node

Too avoid all of these errors caused by too many needed input boxes, and to give a helpful error message to the users with a hint how many ERG and/or tokens can be sent with a certain set input boxes restriction, this adds an optional input box selection restriction to BoxOperations. When the amount of selected (not loaded) input boxes is exceeded, an exception is thrown that can be used to give the user helpful hints.

If the restriction is not set, the behaviour does not change.