### PR TITLE
Add methods to access spent boxes and save to registers

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -1,3 +1,8 @@
+[4.0.12]
+- getBoxById(String boxId) was replaced by getBoxById(String boxId, boolean findInPool, boolean findInSpent)
+  the old behaviour (returning only confirmed unspent boxes) can be achieved by calling
+  getBoxById(boxId, false, false)
+
 [4.0.9]
 - ExplorerAndPoolUnspentBoxesLoader moved from package org.ergoplatform.appkit.impl to org.ergoplatform.appkit
 - DefaultApi.getApiV1AddressesP1Transactions new parameter "concise" - use false for old behaviour

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainDataSource.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainDataSource.java
@@ -24,7 +24,7 @@ public interface BlockchainDataSource {
     List<BlockHeader> getLastBlockHeaders(int count, boolean onlyFullHeaders);
 
     /**
-     * Get box contents for a box by a unique identifier for use as an Input
+     * Get box contents for an unspent box by a unique identifier for use as an Input
      *
      * @param boxId ID of a wanted box (required)
      * @return InputBox
@@ -32,12 +32,21 @@ public interface BlockchainDataSource {
     InputBox getBoxById(String boxId);
 
     /**
-     * Get box contents for a box by a unique identifier for use as an Input, including mempool boxes
+     * Get box contents for an unspent box by a unique identifier for use as an Input,
+     * including mempool boxes
      *
      * @param boxId ID of a wanted box (required)
      * @return InputBox
      */
     InputBox getBoxByIdWithMemPool(String boxId);
+
+    /**
+     * Get box contents for an unspent or spent box by a unique identifier for use as register
+     * contents or for informational purposes
+     * @param boxId
+     * @return InputBox
+     */
+    InputBox getBoxByIdWithSpent(String boxId);
 
     /**
      * Send an Ergo transaction

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainDataSource.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BlockchainDataSource.java
@@ -24,29 +24,15 @@ public interface BlockchainDataSource {
     List<BlockHeader> getLastBlockHeaders(int count, boolean onlyFullHeaders);
 
     /**
-     * Get box contents for an unspent box by a unique identifier for use as an Input
-     *
-     * @param boxId ID of a wanted box (required)
-     * @return InputBox
-     */
-    InputBox getBoxById(String boxId);
-
-    /**
      * Get box contents for an unspent box by a unique identifier for use as an Input,
      * including mempool boxes
      *
      * @param boxId ID of a wanted box (required)
+     * @param findInPool whether to find boxes that are currently in mempool
+     * @param findInSpent whether to find boxes that are spent
      * @return InputBox
      */
-    InputBox getBoxByIdWithMemPool(String boxId);
-
-    /**
-     * Get box contents for an unspent or spent box by a unique identifier for use as register
-     * contents or for informational purposes
-     * @param boxId
-     * @return InputBox
-     */
-    InputBox getBoxByIdWithSpent(String boxId);
+    InputBox getBoxById(String boxId, boolean findInPool, boolean findInSpent);
 
     /**
      * Send an Ergo transaction

--- a/lib-api/src/main/java/org/ergoplatform/appkit/InputBox.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/InputBox.java
@@ -1,5 +1,7 @@
 package org.ergoplatform.appkit;
 
+import special.sigma.Box;
+
 /**
  * Interface of UTXO boxes which can be accessed in the blockchain node.
  * Instances of this interface can be {@link BlockchainContext#getBoxesById(String...) obtained}
@@ -50,5 +52,9 @@ public interface InputBox extends TransactionBox {
      */
     byte[] getBytes();
 
+    /**
+     * @return this box as an ergo value to store in a register
+     */
+    ErgoValue<Box> toErgoValue();
 }
 

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/BlockchainContextImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/BlockchainContextImpl.java
@@ -76,7 +76,7 @@ public class BlockchainContextImpl extends BlockchainContextBase {
     public InputBox[] getBoxesById(String... boxIds) throws ErgoClientException {
         List<InputBox> list = new ArrayList<>();
         for (String id : boxIds) {
-            list.add(_dataSource.getBoxById(id));
+            list.add(_dataSource.getBoxById(id, false, false));
         }
         return list.toArray(new InputBox[0]);
     }

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/InputBoxImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/InputBoxImpl.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 
 import org.ergoplatform.ErgoBox;
 import org.ergoplatform.appkit.*;
+import org.ergoplatform.explorer.client.model.OutputInfo;
 import org.ergoplatform.restapi.client.ErgoTransactionOutput;
 import org.ergoplatform.restapi.client.JSON;
 
@@ -13,6 +14,7 @@ import java.util.stream.Stream;
 
 import sigmastate.Values;
 import sigmastate.interpreter.ContextExtension;
+import special.sigma.Box;
 
 public class InputBoxImpl implements InputBox {
     private final ErgoId _id;
@@ -24,6 +26,13 @@ public class InputBoxImpl implements InputBox {
         _id = new ErgoId(JavaHelpers.decodeStringToBytes(boxData.getBoxId()));
         _ergoBox = ScalaBridge.isoErgoTransactionOutput().to(boxData);
         _boxData = boxData;
+        _extension = ContextExtension.empty();
+    }
+
+    public InputBoxImpl(OutputInfo outputInfo) {
+        _id = ErgoId.create(outputInfo.getBoxId());
+        _ergoBox = ScalaBridge.isoExplTransactionOutput().to(outputInfo);
+        _boxData = ScalaBridge.isoErgoTransactionOutput().from(_ergoBox);
         _extension = ContextExtension.empty();
     }
 
@@ -115,5 +124,10 @@ public class InputBoxImpl implements InputBox {
     @Override
     public String toString() {
         return String.format("InputBox(%s, %s)", getId(), getValue());
+    }
+
+    @Override
+    public ErgoValue<Box> toErgoValue() {
+        return ErgoValue.of(getErgoBox());
     }
 }

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/NodeAndExplorerDataSourceImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/NodeAndExplorerDataSourceImpl.java
@@ -157,6 +157,12 @@ public class NodeAndExplorerDataSourceImpl implements BlockchainDataSource {
     }
 
     @Override
+    public InputBox getBoxByIdWithSpent(String boxId) {
+        OutputInfo outputInfo = executeCall(explorerApi.getApiV1BoxesP1(boxId));
+        return new InputBoxImpl(outputInfo);
+    }
+
+    @Override
     public String sendTransaction(SignedTransaction tx) {
         ErgoLikeTransaction ergoTx = ((SignedTransactionImpl) tx).getTx();
         List<ErgoTransactionDataInput> dataInputsData =

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/NodeAndExplorerDataSourceImpl.java
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/NodeAndExplorerDataSourceImpl.java
@@ -145,19 +145,28 @@ public class NodeAndExplorerDataSourceImpl implements BlockchainDataSource {
     }
 
     @Override
-    public InputBox getBoxById(String boxId) {
-        ErgoTransactionOutput boxData = executeCall(nodeUtxoApi.getBoxById(boxId));
+    public InputBox getBoxById(String boxId, boolean findInPool, boolean findInSpent) {
+        if (findInSpent && !findInPool) {
+            return getBoxByIdExplorer(boxId);
+        } else if (!findInSpent) {
+            return getUnspentBoxByIdNode(boxId, findInPool);
+        } else {
+            // find in spent and find in pool => try node first and fall back to explorer
+            try {
+                return getUnspentBoxByIdNode(boxId, findInPool);
+            } catch (Throwable t) {
+                return getBoxByIdExplorer(boxId);
+            }
+        }
+    }
+
+    private InputBox getUnspentBoxByIdNode(String boxId, boolean findInPool) {
+        ErgoTransactionOutput boxData = (findInPool) ? executeCall(nodeUtxoApi.getBoxWithPoolById(boxId))
+            : executeCall(nodeUtxoApi.getBoxById(boxId));
         return new InputBoxImpl(boxData);
     }
 
-    @Override
-    public InputBox getBoxByIdWithMemPool(String boxId) {
-        ErgoTransactionOutput boxData = executeCall(nodeUtxoApi.getBoxWithPoolById(boxId));
-        return new InputBoxImpl(boxData);
-    }
-
-    @Override
-    public InputBox getBoxByIdWithSpent(String boxId) {
+    private InputBox getBoxByIdExplorer(String boxId) {
         OutputInfo outputInfo = executeCall(explorerApi.getApiV1BoxesP1(boxId));
         return new InputBoxImpl(outputInfo);
     }
@@ -208,7 +217,7 @@ public class NodeAndExplorerDataSourceImpl implements BlockchainDataSource {
                 if (output.getAddress().equals(senderAddress) && output.getSpentTransactionId() == null) {
                     // we have an unconfirmed box - get info from node for it
                     try {
-                        InputBox boxInfo = getBoxByIdWithMemPool(output.getBoxId());
+                        InputBox boxInfo = getBoxById(output.getBoxId(), true, false);
                         if (boxInfo != null) {
                             inputBoxes.add(boxInfo);
                         }
@@ -237,7 +246,7 @@ public class NodeAndExplorerDataSourceImpl implements BlockchainDataSource {
         for (OutputInfo box : boxes) {
             String boxId = box.getBoxId();
             try {
-                InputBox boxInfo = getBoxById(boxId);
+                InputBox boxInfo = getBoxById(boxId, false, false);
                 // can be null if node does not know about the box (yet)
                 // instead of throwing an error, we continue with the boxes actually known
                 if (boxInfo != null) {

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ScalaBridge.scala
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ScalaBridge.scala
@@ -191,7 +191,9 @@ object ScalaBridge {
           .boxId(ErgoAlgos.encode(box.id))
           .value(box.value)
           .ergoTree(ErgoAlgos.encode(TreeSerializer.serializeErgoTree(box.ergoTree)))
-          .assets(assets.map(asset => new AssetInstanceInfo().tokenId(asset.getTokenId).amount(asset.getAmount)))
+          .assets(assets.convertTo[IndexedSeq[Asset]].zipWithIndex
+            .map{ case (asset: Asset, idx: Int) => new AssetInstanceInfo().tokenId(asset.getTokenId).amount(asset.getAmount).index(idx) }
+            .convertTo[JList[AssetInstanceInfo]])
           .additionalRegisters(regs)
           .creationHeight(box.creationHeight)
           .transactionId(box.transactionId)

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ScalaBridge.scala
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ScalaBridge.scala
@@ -1,10 +1,11 @@
 package org.ergoplatform.appkit.impl
 
 import _root_.org.ergoplatform.restapi.client._
-import org.ergoplatform.explorer.client.model.{AdditionalRegister, AdditionalRegisters => ERegisters, AssetInfo => EAsset}
+import org.ergoplatform.explorer.client.model.{AdditionalRegister, AssetInstanceInfo, OutputInfo, AdditionalRegisters => ERegisters, AssetInfo => EAsset}
 
 import java.util
 import java.util.List
+import java.util.{Map => JMap, List => JList}
 import java.lang.{Byte => JByte}
 import org.ergoplatform.ErgoBox.{NonMandatoryRegisterId, TokenId}
 import org.ergoplatform.{DataInput, ErgoBox, ErgoLikeTransaction, Input}
@@ -146,7 +147,7 @@ object ScalaBridge {
     override def to(boxData: ErgoTransactionOutput): ErgoBox = {
       val tree= boxData.getErgoTree.convertTo[ErgoTree]
       val tokens = boxData.getAssets.convertTo[Coll[(TokenId, Long)]]
-      val regs = boxData.getAdditionalRegisters().convertTo[AdditionalRegisters]
+      val regs = boxData.getAdditionalRegisters.convertTo[AdditionalRegisters]
       new ErgoBox(boxData.getValue, tree,
         tokens, regs,
         ModifierId @@ boxData.getTransactionId,
@@ -170,33 +171,34 @@ object ScalaBridge {
     }
   }
 
-//  implicit val isoExplTransactionOutput: Iso[TransactionOutput, ErgoBox] = new Iso[TransactionOutput, ErgoBox] {
-//    override def to(boxData: TransactionOutput): ErgoBox = {
-//      val tree = boxData.getErgoTree.convertTo[ErgoTree]
-//      val tokens = boxData.getAssets.convertTo[Coll[(TokenId, Long)]]
-//      val regs = boxData.getAdditionalRegisters().convertTo[AdditionalRegisters]
-//      new ErgoBox(boxData.getValue, tree,
-//        tokens, regs,
-//        ModifierId @@ boxData.getTransactionId,
-//        boxData.getIndex.shortValue,
-//        boxData.getCreationHeight)
-//    }
-//
-//    override def from(box: ErgoBox): ErgoTransactionOutput = {
-//      val assets = box.additionalTokens.convertTo[List[Asset]]
-//      val regs = isoRegistersToMap.from(box.additionalRegisters)
-//      val out = new ErgoTransactionOutput()
-//          .boxId(ErgoAlgos.encode(box.id))
-//          .value(box.value)
-//          .ergoTree(ErgoAlgos.encode(TreeSerializer.serializeErgoTree(box.ergoTree)))
-//          .assets(assets)
-//          .additionalRegisters(regs)
-//          .creationHeight(box.creationHeight)
-//          .transactionId(box.transactionId)
-//          .index(box.index)
-//      out
-//    }
-//  }
+  implicit val isoExplTransactionOutput: Iso[OutputInfo, ErgoBox] = new Iso[OutputInfo, ErgoBox] {
+    override def to(boxData: OutputInfo): ErgoBox = {
+      val tree = boxData.getErgoTree.convertTo[ErgoTree]
+      val tokens = boxData.getAssets.convertTo[IndexedSeq[AssetInstanceInfo]].sortBy(_.getIndex)
+        .map(asset => new ErgoToken(asset.getTokenId, asset.getAmount)).convertTo[JList[ErgoToken]].convertTo[Coll[(TokenId, Long)]]
+      val regs = boxData.getAdditionalRegisters.convertTo[AdditionalRegisters]
+      new ErgoBox(boxData.getValue, tree,
+        tokens, regs,
+        ModifierId @@ boxData.getTransactionId,
+        boxData.getIndex.shortValue,
+        boxData.getCreationHeight)
+    }
+
+    override def from(box: ErgoBox): OutputInfo = {
+      val assets = box.additionalTokens.convertTo[List[Asset]]
+      val regs = isoExplRegistersToMap.from(box.additionalRegisters)
+      val out = new OutputInfo()
+          .boxId(ErgoAlgos.encode(box.id))
+          .value(box.value)
+          .ergoTree(ErgoAlgos.encode(TreeSerializer.serializeErgoTree(box.ergoTree)))
+          .assets(assets.map(asset => new AssetInstanceInfo().tokenId(asset.getTokenId).amount(asset.getAmount)))
+          .additionalRegisters(regs)
+          .creationHeight(box.creationHeight)
+          .transactionId(box.transactionId)
+          .index(box.index)
+      out
+    }
+  }
 
   implicit val isoBlockHeader: Iso[BlockHeader, Header] = new Iso[BlockHeader, Header] {
     override def to(h: BlockHeader): Header =

--- a/lib-impl/src/test/java/org/ergoplatform/appkit/impl/BlockchainContextImplTest.java
+++ b/lib-impl/src/test/java/org/ergoplatform/appkit/impl/BlockchainContextImplTest.java
@@ -102,22 +102,12 @@ public class BlockchainContextImplTest extends ApiTestBase {
         }
 
         @Override
-        public InputBox getBoxById(String boxId) {
+        public InputBox getBoxById(String boxId, boolean findInPool, boolean findInSpent) {
             return null;
         }
 
         @Override
         public List<InputBox> getUnconfirmedUnspentBoxesFor(Address address, int offset, int limit) {
-            return null;
-        }
-
-        @Override
-        public InputBox getBoxByIdWithMemPool(String boxId) {
-            return null;
-        }
-
-        @Override
-        public InputBox getBoxByIdWithSpent(String boxId) {
             return null;
         }
 

--- a/lib-impl/src/test/java/org/ergoplatform/appkit/impl/BlockchainContextImplTest.java
+++ b/lib-impl/src/test/java/org/ergoplatform/appkit/impl/BlockchainContextImplTest.java
@@ -117,6 +117,11 @@ public class BlockchainContextImplTest extends ApiTestBase {
         }
 
         @Override
+        public InputBox getBoxByIdWithSpent(String boxId) {
+            return null;
+        }
+
+        @Override
         public List<Transaction> getUnconfirmedTransactions(int offset, int limit) {
             return null;
         }


### PR DESCRIPTION
Mgpai discovered that retrieving spent boxes to use them in box registers is currently not straightforward with appkit. This PR adds methods to make this task more easy for client code:

* `BlockchainDataSource#getBoxByIdWithSpent`
* `InputBox#toErgoValue`
* `InputBoxImpl` constructor for Explorer OutputInfo (used by `BlockchainDataSource#getBoxByIdWithSpent`)