### PR TITLE
Excludes tests from javaClientGenerated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Runs tests and collect coverage
-        run: sbt -jvm-opts ci/ci.jvmopts ++${{ matrix.scala }} test
+        run: sbt -jvm-opts ci/ci.jvmopts ++${{ matrix.scala }} "project appkit" test; sbt -jvm-opts ci/ci.jvmopts ++${{ matrix.scala }} "project common" test; sbt -jvm-opts ci/ci.jvmopts ++${{ matrix.scala }} "project libImpl" test
       # - name: Upload coverage report
       #   run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
       #   env:


### PR DESCRIPTION
Due to problems on GitHub actions, or with explorer or node, this deactivates running the javaClientGenerated project in CI tests.

Excluding by tag was not possible because this module is a JUnit test runner. So only option I found is to list the other projects.