### PR TITLE
Use InputBoxesValidator instead of DefaultBoxSelector

### DIFF
--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -441,6 +441,8 @@ class TxBuilderSpec extends PropSpec with Matchers
         .build()
 
       // both boxes should be selected
+      // ergo-wallet's DefaultBoxSelector discarded the second input because it is not necessary for
+      // the outputs, so this test checks if all inputs are used (size 2)
       tx.getInputs.size() shouldBe 2
       tx.getOutputs.size() shouldBe 3
 

--- a/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/BoxOperations.java
@@ -242,11 +242,11 @@ public class BoxOperations {
     }
 
     /**
-     * Like {@link #loadTop()}, but this method allows giving a nanoerg amount that is not needed
-     * to be covered. Use this method if you have to provide boxes manually for the transaction,
-     * but need to load missing amounts with this method.
+     * Like {@link #loadTop()} loading and returning unspent boxes covering the given amount of
+     * nanoergs, fee and tokens, but you can specify an amount of nanoergs that is already covered
+     * by other input boxes and does not need to be satisfied.
      *
-     * @param amountCovered amount not needed to be covered by boxes loaded
+     * @param amountCovered nanoerg amount that is assumed to be covered by input boxes you provide
      */
     public List<InputBox> loadTop(long amountCovered) {
         List<InputBox> unspentBoxes = new ArrayList<>();

--- a/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidator.scala
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidator.scala
@@ -1,0 +1,109 @@
+package org.ergoplatform.appkit
+
+import org.ergoplatform.wallet.Constants.MaxAssetsPerBox
+import org.ergoplatform.wallet.boxes.BoxSelector._
+import org.ergoplatform.wallet.boxes.DefaultBoxSelector._
+import org.ergoplatform.wallet.boxes.{BoxSelector, ReemissionData}
+import org.ergoplatform.wallet.{AssetUtils, TokensMap}
+import org.ergoplatform.{ErgoBoxAssets, ErgoBoxAssetsHolder}
+import scorex.util.ModifierId
+import sigmastate.utils.Helpers.EitherOps
+
+import scala.collection.mutable
+
+/**
+  * Pass through implementation of the box selector. Unlike DefaultBoxSelector from ergo-wallet,
+  * it does not select input boxes. We do this in appkit ourselves and do not need the selector
+  * to interfere with how we built our transaction. Instead, this selector performs validation
+  * and calculates the necessary change box
+  */
+class InputBoxesValidator extends BoxSelector {
+
+  override def reemissionDataOpt: Option[ReemissionData] = None
+
+  override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
+                                          externalFilter: T => Boolean,
+                                          targetBalance: Long,
+                                          targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+    //mutable structures to collect results
+    val res = mutable.Buffer[T]()
+    var currentBalance = 0L
+    val currentAssets = mutable.Map[ModifierId, Long]()
+
+    // select all input boxes - we only validate here
+    while (inputBoxes.hasNext) {
+      val box = inputBoxes.next()
+      currentBalance = currentBalance + box.value
+      AssetUtils.mergeAssetsMut(currentAssets, box.tokens)
+      res += box
+    }
+
+    if (currentBalance - targetBalance >= 0) {
+      //now check if we found all tokens
+      if (targetAssets.forall {
+        case (id, targetAmt) => currentAssets.getOrElse(id, 0L) >= targetAmt
+      }) {
+        formChangeBoxes(currentBalance, targetBalance, currentAssets, targetAssets).mapRight { changeBoxes =>
+          BoxSelectionResult(res, changeBoxes)
+        }
+      } else {
+        Left(NotEnoughTokensError(
+          s"not enough boxes to meet token needs $targetAssets (found only $currentAssets)", currentAssets.toMap)
+        )
+      }
+    } else {
+      Left(NotEnoughErgsError(
+        s"not enough boxes to meet ERG needs $targetBalance (found only $currentBalance)", currentBalance)
+      )
+    }
+  }
+
+  /**
+    * Helper method to construct change outputs
+    *
+    * @param foundBalance    - ERG balance of boxes collected
+    *                        (spendable only, so after possibly deducting re-emission tokens)
+    * @param targetBalance   - ERG amount to be transferred to recipients
+    * @param foundBoxAssets  - assets balances of boxes
+    * @param targetBoxAssets - assets amounts to be transferred to recipients
+    * @return
+    */
+  def formChangeBoxes(foundBalance: Long,
+                      targetBalance: Long,
+                      foundBoxAssets: mutable.Map[ModifierId, Long],
+                      targetBoxAssets: TokensMap): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
+    AssetUtils.subtractAssetsMut(foundBoxAssets, targetBoxAssets)
+    val changeBoxesAssets: Seq[mutable.Map[ModifierId, Long]] = foundBoxAssets.grouped(MaxAssetsPerBox).toSeq
+    val changeBalance = foundBalance - targetBalance
+    //at least a minimum amount of ERG should be assigned per a created box
+    if (changeBoxesAssets.size * MinBoxValue > changeBalance) {
+      Left(NotEnoughCoinsForChangeBoxesError(
+        s"Not enough nanoERGs ($changeBalance nanoERG) to create ${changeBoxesAssets.size} change boxes, \nfor $changeBoxesAssets"
+      ))
+    } else {
+      val changeBoxes = if (changeBoxesAssets.nonEmpty) {
+        val baseChangeBalance = changeBalance / changeBoxesAssets.size
+
+        val changeBoxesNoBalanceAdjusted = changeBoxesAssets.map { a =>
+          ErgoBoxAssetsHolder(baseChangeBalance, a.toMap)
+        }
+
+        val modifiedBoxOpt = changeBoxesNoBalanceAdjusted.headOption.map { firstBox =>
+          ErgoBoxAssetsHolder(
+            changeBalance - baseChangeBalance * (changeBoxesAssets.size - 1),
+            firstBox.tokens
+          )
+        }
+
+        modifiedBoxOpt.toSeq ++ changeBoxesNoBalanceAdjusted.tail
+      } else if (changeBalance > 0) {
+        Seq(ErgoBoxAssetsHolder(changeBalance))
+      } else {
+        Seq.empty
+      }
+
+      Right(changeBoxes)
+    }
+  }
+
+}

--- a/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidator.scala
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidator.scala
@@ -31,8 +31,7 @@ class InputBoxesValidator extends BoxSelector {
     val currentAssets = mutable.Map[ModifierId, Long]()
 
     // select all input boxes - we only validate here
-    while (inputBoxes.hasNext) {
-      val box = inputBoxes.next()
+    inputBoxes.foreach { box: T =>
       currentBalance = currentBalance + box.value
       AssetUtils.mergeAssetsMut(currentAssets, box.tokens)
       res += box

--- a/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidator.scala
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidator.scala
@@ -48,7 +48,7 @@ class InputBoxesValidator extends BoxSelector {
         }
       } else {
         Left(NotEnoughTokensError(
-          s"not enough boxes to meet token needs $targetAssets (found only $currentAssets)", currentAssets.toMap)
+          s"Not enough tokens in input boxes to send $targetAssets (found only $currentAssets)", currentAssets.toMap)
         )
       }
     } else {

--- a/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidatorJavaHelper.scala
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidatorJavaHelper.scala
@@ -20,7 +20,9 @@ object InputBoxesValidatorJavaHelper {
 
     override def tokens: Map[ModifierId, Long] = {
       val tokens = mutable.Map[ModifierId, Long]()
-      inputBox.getTokens.forEach(token => AssetUtils.mergeAssetsMut(tokens, Map.apply(bytesToId(token.getId.getBytes) -> token.getValue)))
+      inputBox.getTokens.convertTo[IndexedSeq[ErgoToken]].foreach { token: ErgoToken =>
+        AssetUtils.mergeAssetsMut(tokens, Map.apply(bytesToId(token.getId.getBytes) -> token.getValue))
+      }
       tokens.toMap
     }
   }

--- a/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidatorJavaHelper.scala
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidatorJavaHelper.scala
@@ -1,40 +1,39 @@
 package org.ergoplatform.appkit
 
-import scala.collection.mutable
-import org.ergoplatform.wallet.boxes.DefaultBoxSelector
-import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughCoinsForChangeBoxesError
-import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughErgsError
-import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughTokensError
-
-import java.util.{List => JList, Map => JMap}
-import org.ergoplatform.appkit.JavaHelpers._
-import org.ergoplatform.appkit.Iso._
-import org.ergoplatform.ErgoBox.TokenId
 import org.ergoplatform.ErgoBoxAssets
-import org.ergoplatform.ErgoBoxAssetsHolder
 import org.ergoplatform.appkit.InputBoxesSelectionException.{NotEnoughErgsException, NotEnoughTokensException}
+import org.ergoplatform.appkit.Iso._
+import org.ergoplatform.appkit.JavaHelpers._
+import org.ergoplatform.wallet.AssetUtils
+import org.ergoplatform.wallet.boxes.DefaultBoxSelector.{NotEnoughCoinsForChangeBoxesError, NotEnoughErgsError, NotEnoughTokensError}
 import scorex.util.{ModifierId, bytesToId}
 
 import java.util
+import java.util.{List => JList}
+import scala.collection.mutable
 
 
-object BoxSelectorsJavaHelpers {
+object InputBoxesValidatorJavaHelper {
 
   final case class InputBoxWrapper(val inputBox: InputBox) extends ErgoBoxAssets {
     override def value: Long = inputBox.getValue
-    override def tokens: Map[ModifierId, Long] = 
-      inputBox.getTokens.convertTo[mutable.LinkedHashMap[ModifierId, Long]].toMap
+
+    override def tokens: Map[ModifierId, Long] = {
+      val tokens = mutable.Map[ModifierId, Long]()
+      inputBox.getTokens.forEach(token => AssetUtils.mergeAssetsMut(tokens, Map.apply(bytesToId(token.getId.getBytes) -> token.getValue)))
+      tokens.toMap
+    }
   }
 
-  def selectBoxes(unspentBoxes: JList[InputBox],
-                  amountToSpend: Long,
-                  tokensToSpend: JList[ErgoToken]): JList[InputBox] = {
+  def validateBoxes(unspentBoxes: JList[InputBox],
+                    amountToSpend: Long,
+                    tokensToSpend: JList[ErgoToken]): Unit = {
     val inputBoxes = unspentBoxes.convertTo[IndexedSeq[InputBox]]
-      .map(InputBoxWrapper.apply).toIterator
+      .map(InputBoxWrapper.apply)
     val targetAssets = tokensToSpend.convertTo[mutable.LinkedHashMap[ModifierId, Long]].toMap
-    val foundBoxes: IndexedSeq[InputBox] = new DefaultBoxSelector(None).select(inputBoxes, amountToSpend, targetAssets) match {
+    new InputBoxesValidator().select(inputBoxes.toIterator, amountToSpend, targetAssets) match {
       case Left(err: NotEnoughCoinsForChangeBoxesError) =>
-          throw new InputBoxesSelectionException.NotEnoughCoinsForChangeException(err.message)
+        throw new InputBoxesSelectionException.NotEnoughCoinsForChangeException(err.message)
       case Left(err: NotEnoughErgsError) => {
         // we might have a ChangeBox error here as well, so let's report it correctly
         if (err.balanceFound >= amountToSpend) {
@@ -53,9 +52,8 @@ object BoxSelectorsJavaHelpers {
       case Left(err) =>
         throw new InputBoxesSelectionException(
           s"Not enough funds in boxes to pay $amountToSpend nanoERGs, \ntokens: $tokensToSpend, \nreason: $err")
-      case Right(v) => v.boxes.map(_.inputBox).toIndexedSeq
+      case Right(v) => // do nothing, everything alright
     }
-    foundBoxes.convertTo[JList[InputBox]]
   }
 
 }

--- a/lib-impl/src/main/java/org/ergoplatform/appkit/impl/UnsignedTransactionBuilderImpl.scala
+++ b/lib-impl/src/main/java/org/ergoplatform/appkit/impl/UnsignedTransactionBuilderImpl.scala
@@ -1,22 +1,19 @@
 package org.ergoplatform.appkit.impl
 
-import java.util
 import org.ergoplatform._
-import org.ergoplatform.appkit.{Iso, _}
+import org.ergoplatform.appkit.JavaHelpers._
+import org.ergoplatform.appkit.Parameters.{MinChangeValue, MinFee}
+import org.ergoplatform.appkit._
 import org.ergoplatform.wallet.protocol.context.ErgoLikeStateContext
 import org.ergoplatform.wallet.transactions.TransactionBuilder
-import org.ergoplatform.wallet.boxes.DefaultBoxSelector
-import org.ergoplatform.wallet.boxes.BoxSelector
+import scorex.crypto.authds.ADDigest
+import sigmastate.eval.Colls
 import special.collection.Coll
 import special.sigma.Header
 
+import java.util
 import java.util._
 import java.util.stream.Collectors
-import org.ergoplatform.appkit.Parameters.{MinChangeValue, MinFee}
-import scorex.crypto.authds.ADDigest
-import org.ergoplatform.appkit.JavaHelpers._
-import sigmastate.eval.Colls
-
 import scala.collection.JavaConversions
 
 class UnsignedTransactionBuilderImpl(val _ctx: BlockchainContextImpl) extends UnsignedTransactionBuilder {
@@ -131,7 +128,7 @@ class UnsignedTransactionBuilderImpl(val _ctx: BlockchainContextImpl) extends Un
       changeAddress = changeAddress, minChangeValue = MinChangeValue,
       minerRewardDelay = rewardDelay,
       burnTokens = burnTokens,
-      boxSelector = new DefaultBoxSelector(None)).get
+      boxSelector = new InputBoxesValidator()).get
 
     // the method above don't accept ContextExtension along with inputs, thus, after the
     // transaction has been built we need to zip with the extensions that have been


### PR DESCRIPTION
Closes #182

This removes usage of DefaultBoxSelector as we already select boxes either by `BoxOperations` or manually. Instead, we introduced `InputBoxesValidator` to do validations and change box calculation that the selector did and to be compatrible to `TransactionsBuilder`.