### PR TITLE
Fix ClassCastException introduced in #202

### DIFF
--- a/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
+++ b/appkit/src/test/scala/org/ergoplatform/appkit/TxBuilderSpec.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.appkit
 
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import org.ergoplatform.appkit.InputBoxesSelectionException.{InputBoxLimitExceededException, NotEnoughErgsException}
+import org.ergoplatform.appkit.InputBoxesSelectionException.{InputBoxLimitExceededException, NotEnoughCoinsForChangeException, NotEnoughErgsException}
 import org.ergoplatform.appkit.JavaHelpers._
 import org.ergoplatform.appkit.examples.RunMockedScala.data
 import org.ergoplatform.appkit.impl.{Eip4TokenBuilder, ErgoTreeContract}
@@ -404,6 +404,16 @@ class TxBuilderSpec extends PropSpec with Matchers
       assertExceptionThrown(
         operations.withMaxInputBoxesToSelect(1).loadTop(),
         exceptionLike[InputBoxLimitExceededException]("could not cover 1000000 nanoERG")
+      )
+
+      // if there is only a single input box, we face NotEnoughCoinsForChangeException
+      val operations2 = BoxOperations.createForSenders(senders, ctx)
+        .withAmountToSpend(amountToSend)
+        .withInputBoxesLoader(new MockedBoxesLoader(util.Arrays.asList(input1)))
+
+      assertExceptionThrown(
+        operations2.loadTop(),
+        exceptionLike[NotEnoughCoinsForChangeException]()
       )
     }
 

--- a/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidator.scala
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/InputBoxesValidator.scala
@@ -7,7 +7,6 @@ import org.ergoplatform.wallet.boxes.{BoxSelector, ReemissionData}
 import org.ergoplatform.wallet.{AssetUtils, TokensMap}
 import org.ergoplatform.{ErgoBoxAssets, ErgoBoxAssetsHolder}
 import scorex.util.ModifierId
-import sigmastate.utils.Helpers.EitherOps
 
 import scala.collection.mutable
 
@@ -42,8 +41,9 @@ class InputBoxesValidator extends BoxSelector {
       if (targetAssets.forall {
         case (id, targetAmt) => currentAssets.getOrElse(id, 0L) >= targetAmt
       }) {
-        formChangeBoxes(currentBalance, targetBalance, currentAssets, targetAssets).mapRight { changeBoxes =>
-          BoxSelectionResult(res, changeBoxes)
+        formChangeBoxes(currentBalance, targetBalance, currentAssets, targetAssets) match {
+          case Right(changeBoxes) => Right(BoxSelectionResult(res, changeBoxes))
+          case Left(error) => Left(error)
         }
       } else {
         Left(NotEnoughTokensError(


### PR DESCRIPTION
Changes in #202 could end up in

      java.lang.ClassCastException: class sigmastate.utils.Helpers$EitherOps cannot be cast to class scala.util.Either (sigmastate.utils.Helpers$EitherOps and scala.util.Either are in unnamed module of loader 'app')

instead of throwing NotEnoughCoinsForChangeException. This PR fixes this and adds the missing test case.