### PR TITLE
Transactions API: Fix getUnconfirmedTransactionsByErgoTree text/plain mode

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -1,3 +1,8 @@
+[5.0.3]
+- Node transactions API getUnconfirmedTransactionsByErgoTree: In past versions, it was needed to
+  wrap the ergotree param in quotes when ScalarsConverterFactory was used for Retrofit. This is fixed
+  and the workaround needs to be removed when used.
+
 [5.0.0]
 - block version now required to construct ColdErgoClient
 - getBoxById(String boxId) was replaced by getBoxById(String boxId, boolean findInPool, boolean findInSpent)

--- a/java-client-generated/src/main/java/org/ergoplatform/restapi/client/TransactionsApi.java
+++ b/java-client-generated/src/main/java/org/ergoplatform/restapi/client/TransactionsApi.java
@@ -101,9 +101,6 @@ public interface TransactionsApi {
    * @return Call&lt;Transactions&gt;
    */
   @POST("transactions/unconfirmed/byErgoTree")
-  @Headers({
-      "Content-Type:application/json"
-  })
   Call<Transactions> getUnconfirmedTransactionsByErgoTree(
       @retrofit2.http.Body String ergoTreeHex, @retrofit2.http.Query("offset") Integer offset,     @retrofit2.http.Query("limit") Integer limit
   );


### PR DESCRIPTION
In past versions, it was needed to wrap the ergotree param in quotes when ScalarsConverterFactory was used for Retrofit. This is fixed and the workaround needs to be removed when used.