### PR TITLE
fix(BoxSelector): Improve UnspentBoxesLoader memory & mutability safety

### DIFF
--- a/lib-api/src/main/java/org/ergoplatform/appkit/ExplorerAndPoolUnspentBoxesLoader.java
+++ b/lib-api/src/main/java/org/ergoplatform/appkit/ExplorerAndPoolUnspentBoxesLoader.java
@@ -3,7 +3,11 @@ package org.ergoplatform.appkit;
 import org.ergoplatform.sdk.ErgoToken;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
@@ -18,7 +22,9 @@ import javax.annotation.Nonnull;
  * Optionally, you can also use boxes available on mempool to be spent, allowing to make chained tx.
  */
 public class ExplorerAndPoolUnspentBoxesLoader extends BoxOperations.ExplorerApiWithCheckerLoader {
-    private final List<String> unconfirmedSpentBoxesIds = new ArrayList<>();
+    private static final Logger logger = Logger.getLogger(ExplorerAndPoolUnspentBoxesLoader.class.getName());
+
+    private final Set<String> unconfirmedSpentBoxesIds = new HashSet<>();
     private boolean unconfirmedBoxesFetched;
     private boolean allowChainedTx = false;
 
@@ -58,14 +64,17 @@ public class ExplorerAndPoolUnspentBoxesLoader extends BoxOperations.ExplorerApi
 
             // fetch unconfirmed transactions for this address and add its boxes as last page
             try {
-                inputBoxes.addAll(ctx.getDataSource().getUnconfirmedUnspentBoxesFor(sender, 0, 50));
+                List<InputBox> unconfirmedBoxes = ctx.getDataSource().getUnconfirmedUnspentBoxesFor(sender, 0, 50);
+                // Defensive copy: super.loadBoxesPage() may return an immutable list,
+                // and addAll() on an unmodifiable list throws UnsupportedOperationException.
+                List<InputBox> mutableResult = new ArrayList<>(inputBoxes);
+                mutableResult.addAll(unconfirmedBoxes);
+                return mutableResult;
             } catch (Throwable t) {
-                // something did not work - bad luck but just proceed without chained tx
+                logger.log(Level.WARNING, "Failed to fetch unconfirmed boxes for chained tx", t);
             }
         }
 
         return inputBoxes;
     }
 }
-
-


### PR DESCRIPTION
## Summary

This PR improves the memory safety and debuggability of `ExplorerAndPoolUnspentBoxesLoader`, the core box selection component used for chained transaction support.

### Changes

#### 1. `ArrayList` → `HashSet` for blacklist (O(n) → O(1))

The `unconfirmedSpentBoxesIds` collection is used exclusively for membership checks via `contains()` in `canUseBox()`. Under high mempool congestion (1000+ unconfirmed transactions), the linear scan of `ArrayList.contains()` becomes a measurable bottleneck during box selection. `HashSet` provides O(1) constant-time lookups.

```diff
-private final List<String> unconfirmedSpentBoxesIds = new ArrayList<>();
+private final Set<String> unconfirmedSpentBoxesIds = new HashSet<>();
```

#### 2. Defensive copy in `loadBoxesPage()` 

`super.loadBoxesPage()` may return an immutable list (e.g. `Collections.unmodifiableList` or `List.of()`). Calling `addAll()` on such a list throws `UnsupportedOperationException`, which is currently swallowed by the `catch (Throwable)` block — silently breaking chained transaction support with no indication to the caller.

The fix creates a mutable `ArrayList` copy before adding unconfirmed boxes.

#### 3. Logging in catch block

The `catch (Throwable)` block previously swallowed all exceptions silently, making it impossible to debug chained transaction failures in production. A `java.util.logging` call now surfaces these errors while preserving the graceful degradation behavior.

### Impact

- **Zero breaking changes** — all public API signatures are identical
- **Binary compatible** — `Set` is a supertype behavior-wise; `canUseBox()` and `prepare()` signatures unchanged
- **Benefits all downstream consumers** — ergo-wallet-app, any dApp using `BoxOperations` with `ExplorerAndPoolUnspentBoxesLoader`

### Related

- ergoplatform/ergo-wallet-app#209 (chained transaction handling)